### PR TITLE
feat(web): sync staging metrics/report flow and bump convoai-api to 2.2.0

### DIFF
--- a/Web/Scenes/VoiceAgent/messages/en-US.json
+++ b/Web/Scenes/VoiceAgent/messages/en-US.json
@@ -174,6 +174,11 @@
     "voice-lock": {
       "title": "Voice Lock",
       "description": "Voice Lock (TODO)"
+    },
+    "report": {
+      "title": "Data Report",
+      "view": "View Report",
+      "empty": "No data yet"
     }
   },
   "agent": {
@@ -312,6 +317,9 @@
     "max-image-dimensions": "Image dimensions must not exceed 2048x2048 pixels.",
     "upload-image-tooltip": "Image size up to 5MB, dimensions under 2048x2048. Supports JPG, PNG, WEBP, JPEG formats.",
     "avatar-busy-error": "All avatars are busy now. Please try again later."
+  },
+  "report": {
+    "realtime": "Realtime Data"
   },
   "preset": {
     "more": "More+",

--- a/Web/Scenes/VoiceAgent/messages/zh-CN.json
+++ b/Web/Scenes/VoiceAgent/messages/zh-CN.json
@@ -174,6 +174,11 @@
     "voice-lock": {
       "title": "声纹锁定",
       "description": "声纹锁定 TODO"
+    },
+    "report": {
+      "title": "数据报告",
+      "view": "查看报告",
+      "empty": "暂无数据"
     }
   },
   "agent": {
@@ -312,6 +317,9 @@
     "max-image-dimensions": "图片尺寸不得超过2048x2048像素。",
     "upload-image-tooltip": "图片大小5M以内，尺寸小于2048x2048。支持JPG、PNG、WEBP、JPEG格式",
     "avatar-busy-error": "所有数字人正忙，请稍后重试。"
+  },
+  "report": {
+    "realtime": "实时数据"
   },
   "preset": {
     "more": "更多+",

--- a/Web/Scenes/VoiceAgent/src/app/api/agent/metrics/[agentId]/route.ts
+++ b/Web/Scenes/VoiceAgent/src/app/api/agent/metrics/[agentId]/route.ts
@@ -1,0 +1,20 @@
+import { type NextRequest, NextResponse } from 'next/server'
+import { getEndpointFromNextRequest } from '@/app/api/_utils'
+import { REMOTE_CONVOAI_AGENT_METRICS } from '@/constants'
+
+export async function GET(
+  request: NextRequest,
+  context: { params: Promise<{ agentId: string }> }
+) {
+  const { agentServer } = getEndpointFromNextRequest(request)
+  const { agentId } = await context.params
+
+  const url = `${agentServer}${REMOTE_CONVOAI_AGENT_METRICS(agentId)}`
+  const res = await fetch(url, {
+    method: 'GET',
+    cache: 'no-store'
+  })
+
+  const data = await res.json()
+  return NextResponse.json(data, { status: res.status })
+}

--- a/Web/Scenes/VoiceAgent/src/app/api/agent/metrics/report/route.ts
+++ b/Web/Scenes/VoiceAgent/src/app/api/agent/metrics/report/route.ts
@@ -1,0 +1,30 @@
+import { type NextRequest, NextResponse } from 'next/server'
+import { getEndpointFromNextRequest } from '@/app/api/_utils'
+import { REMOTE_CONVOAI_AGENT_METRICS_REPORT } from '@/constants'
+
+export async function POST(request: NextRequest) {
+  const { agentServer, authorizationHeader } =
+    getEndpointFromNextRequest(request)
+
+  if (!authorizationHeader) {
+    return NextResponse.json(
+      { code: 1, msg: 'Authorization header missing' },
+      { status: 401 }
+    )
+  }
+
+  const body = await request.json()
+  const url = `${agentServer}${REMOTE_CONVOAI_AGENT_METRICS_REPORT}`
+
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: authorizationHeader
+    },
+    body: JSON.stringify(body)
+  })
+
+  const data = await res.json()
+  return NextResponse.json(data, { status: res.status })
+}

--- a/Web/Scenes/VoiceAgent/src/app/api/agent/route.test.ts
+++ b/Web/Scenes/VoiceAgent/src/app/api/agent/route.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+
+const getEndpointFromNextRequest = mock(() => ({
+  agentServer: 'https://agent.example.com',
+  devMode: false,
+  endpoint: 'https://agent.example.com',
+  appId: 'app-123',
+  authorizationHeader: 'Bearer token',
+  appCert: undefined
+}))
+
+mock.module('@/app/api/_utils', () => ({
+  basicAuthKey: undefined,
+  basicAuthSecret: undefined,
+  getEndpointFromNextRequest
+}))
+
+mock.module('@/lib/logger', () => ({
+  logger: {
+    info: () => {},
+    error: () => {}
+  }
+}))
+
+describe('POST /api/agent', () => {
+  const fetchMock = mock(
+    async (_url: string, _init?: RequestInit) =>
+      new Response(
+        JSON.stringify({
+          code: 0,
+          data: {
+            agent_id: 'agent-123',
+            agent_url: 'https://convo.example.com/agent/123'
+          }
+        }),
+        {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json'
+          }
+        }
+      )
+  )
+
+  beforeEach(() => {
+    fetchMock.mockClear()
+    getEndpointFromNextRequest.mockClear()
+    globalThis.fetch = fetchMock as typeof fetch
+  })
+
+  afterEach(() => {
+    mock.restore()
+  })
+
+  test('sends app_feature fields while keeping legacy advanced_features flags for compatibility', async () => {
+    const { POST } = await import('@/app/api/agent/route')
+
+    const response = await POST({
+      json: async () => ({
+        preset_name: 'intelligent_assistant',
+        app_feature: {
+          enable_aivad: true,
+          pause_state_enabled: true,
+          enable_local_bvc: true
+        },
+        advanced_features: {
+          enable_bhvs: false,
+          enable_rtm: true,
+          enable_sal: false
+        },
+        parameters: {
+          enable_flexible: true
+        },
+        channel: 'demo',
+        agent_rtc_uid: 'agent-uid',
+        remote_rtc_uids: ['user-uid'],
+        asr: {
+          language: 'zh-CN'
+        }
+      })
+    } as never)
+
+    expect(response.status).toBe(200)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    const remoteBody = JSON.parse(String(init.body)) as {
+      app_feature: {
+        enable_aivad: boolean
+        pause_state_enabled: boolean
+        enable_local_bvc: boolean
+      }
+      convoai_body: {
+        properties: {
+          advanced_features: Record<string, unknown>
+          parameters: Record<string, unknown>
+        }
+      }
+    }
+
+    expect(remoteBody.app_feature).toEqual({
+      enable_aivad: true,
+      pause_state_enabled: true,
+      enable_local_bvc: true
+    })
+    expect(remoteBody.convoai_body.properties.advanced_features).toEqual({
+      enable_aivad: true,
+      enable_bhvs: false,
+      enable_rtm: true,
+      enable_sal: false
+    })
+    expect(remoteBody.convoai_body.properties.parameters.enable_flexible).toBe(
+      undefined
+    )
+  })
+})

--- a/Web/Scenes/VoiceAgent/src/app/api/agent/route.ts
+++ b/Web/Scenes/VoiceAgent/src/app/api/agent/route.ts
@@ -38,25 +38,61 @@ export async function POST(request: NextRequest) {
 
   try {
     const reqBody = await request.json()
+    const {
+      graph_id,
+      preset,
+      preset_name,
+      preset_type,
+      app_feature,
+      parameters,
+      advanced_features,
+      ...properties
+    } = reqBody
+    const nextParameters = { ...(parameters || {}) }
+    delete nextParameters.enable_flexible
     logger.info({ reqBody, devMode }, 'POST')
+    const nextAppFeature = app_feature
+      ? {
+          enable_aivad: !!app_feature.enable_aivad,
+          pause_state_enabled:
+            !!app_feature.enable_aivad && !!app_feature.pause_state_enabled,
+          enable_local_bvc:
+            app_feature.enable_local_bvc === undefined
+              ? true
+              : !!app_feature.enable_local_bvc
+        }
+      : undefined
     const body = startAgentRequestBodySchema.parse({
       app_id: appId,
       ...(appCert && { app_cert: appCert }),
       ...(basicAuthKey && { basic_auth_username: basicAuthKey }),
       ...(basicAuthSecret && { basic_auth_password: basicAuthSecret }),
-      preset_name: reqBody.preset_name,
-      preset_type: reqBody.preset_type,
+      preset_name,
+      preset_type,
+      app_feature: nextAppFeature,
       convoai_body: {
-        graph_id: reqBody.graph_id,
-        preset: reqBody.preset,
+        graph_id,
+        preset,
         properties: {
-          ...reqBody,
+          ...properties,
+          ...(advanced_features
+            ? {
+                advanced_features: {
+                  enable_aivad:
+                    advanced_features.enable_aivad ??
+                    nextAppFeature?.enable_aivad,
+                  enable_bhvs: advanced_features.enable_bhvs,
+                  enable_rtm: advanced_features.enable_rtm,
+                  enable_sal: advanced_features.enable_sal
+                }
+              }
+            : {}),
           parameters: {
-            ...(reqBody.parameters || {}),
+            ...nextParameters,
             audio_scenario: 'default',
             transcript: {
               enable: true,
-              enable_words: !reqBody?.avatar, // Disable words for avatar
+              enable_words: !properties?.avatar, // Disable words for avatar
               protocol_version: 'v2'
             },
             data_channel: 'rtm',

--- a/Web/Scenes/VoiceAgent/src/app/reports/[agentId]/page.tsx
+++ b/Web/Scenes/VoiceAgent/src/app/reports/[agentId]/page.tsx
@@ -1,0 +1,9 @@
+import { ReportPage } from './report-page'
+
+export default async function Page(props: {
+  params: Promise<{ agentId: string }>
+}) {
+  const { agentId } = await props.params
+
+  return <ReportPage agentId={agentId} />
+}

--- a/Web/Scenes/VoiceAgent/src/app/reports/[agentId]/report-page.tsx
+++ b/Web/Scenes/VoiceAgent/src/app/reports/[agentId]/report-page.tsx
@@ -1,0 +1,236 @@
+'use client'
+
+import { CopyIcon } from 'lucide-react'
+import * as React from 'react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import { buildReportRows } from '@/lib/latency-metrics'
+import { cn } from '@/lib/utils'
+import { getAgentMetrics } from '@/services/agent'
+import { useReportStore } from '@/store'
+import type { IAgentMetrics } from '@/type/report'
+
+export function ReportPage(props: { agentId: string }) {
+  const { agentId } = props
+  const [metrics, setMetrics] = React.useState<IAgentMetrics | null>(null)
+  const [loading, setLoading] = React.useState(true)
+  const [error, setError] = React.useState<string | null>(null)
+  const session = useReportStore((state) => state.sessionsByAgentId[agentId])
+
+  React.useEffect(() => {
+    let cancelled = false
+
+    const load = async () => {
+      setLoading(true)
+      setError(null)
+
+      try {
+        const data = await getAgentMetrics(agentId)
+        if (!cancelled) {
+          setMetrics(data)
+        }
+      } catch (loadError) {
+        if (!cancelled) {
+          setError(
+            loadError instanceof Error ? loadError.message : 'Unknown error'
+          )
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false)
+        }
+      }
+    }
+
+    load()
+
+    return () => {
+      cancelled = true
+    }
+  }, [agentId])
+
+  const report = React.useMemo(() => {
+    if (!metrics && !session?.agentId) {
+      return null
+    }
+
+    return buildReportRows({
+      metrics: metrics || {
+        agent_id: session?.agentId || agentId,
+        channel: session?.channel || '',
+        preset_name: session?.presetName || '',
+        preset_display_name: session?.presetDisplayName || '',
+        call_start_at: session?.callStartAt || 0,
+        turn_event: (session?.turns || []).map((turn) => ({
+          turn_id: turn.turnId,
+          metrics: {
+            e2e_latency_ms: turn.e2eLatencyMs,
+            segmented_latency_ms: [
+              {
+                name: 'algorithm_processing',
+                latency: turn.segmentedLatency.algorithmProcessingMs
+              },
+              { name: 'asr_ttlw', latency: turn.segmentedLatency.asrTtlwMs },
+              { name: 'llm_ttft', latency: turn.segmentedLatency.llmTtftMs },
+              { name: 'tts_ttfb', latency: turn.segmentedLatency.ttsTtfbMs },
+              {
+                name: 'transport',
+                latency: turn.segmentedLatency.transportMs
+              }
+            ]
+          }
+        }))
+      }
+    })
+  }, [agentId, metrics, session])
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(window.location.href)
+      toast.success('链接已复制')
+    } catch {
+      toast.error('复制失败，请手动复制当前地址')
+    }
+  }
+
+  return (
+    <main className='min-h-dvh bg-[#121212] px-4 py-6 text-white md:px-8'>
+      <div className='mx-auto flex max-w-7xl flex-col gap-6'>
+        <header className='flex flex-col gap-3 rounded-2xl border border-white/8 bg-white/4 p-5 md:flex-row md:items-center md:justify-between'>
+          <div className='flex flex-col gap-2'>
+            <div className='text-sm text-white/65'>声网对话式 AI 引擎</div>
+            <h1 className='font-semibold text-2xl'>数据报告</h1>
+          </div>
+          <Button
+            className='w-full md:w-auto'
+            variant='secondary'
+            onClick={handleCopy}
+          >
+            <CopyIcon className='size-4' />
+            复制分享链接
+          </Button>
+        </header>
+
+        {loading && (
+          <section className='rounded-2xl border border-white/8 bg-white/4 p-6 text-white/70'>
+            载入报告中...
+          </section>
+        )}
+
+        {!loading && error && !session?.agentId && (
+          <section className='rounded-2xl border border-red-500/20 bg-red-500/10 p-6 text-red-100'>
+            获取报告失败：{error}
+          </section>
+        )}
+
+        {!loading && report && (
+          <>
+            <section className='grid gap-4 rounded-2xl border border-white/8 bg-white/4 p-5 md:grid-cols-3'>
+              <InfoItem
+                label='通话开始时间'
+                value={formatTimestamp(
+                  metrics?.call_start_at || session?.callStartAt || 0
+                )}
+              />
+              <InfoItem
+                label='智能体名称'
+                value={
+                  metrics?.preset_display_name ||
+                  metrics?.preset_name ||
+                  session?.presetDisplayName ||
+                  session?.presetName ||
+                  '—'
+                }
+              />
+              <InfoItem
+                label='Agent ID'
+                value={metrics?.agent_id || session?.agentId || agentId}
+              />
+            </section>
+
+            <section className='overflow-hidden rounded-2xl border border-white/8 bg-white/4'>
+              <div className='border-white/8 border-b px-5 py-4 font-semibold'>
+                通话延迟明细（单位：ms）
+              </div>
+              <div className='overflow-x-auto'>
+                <table className='w-full min-w-[1180px] text-left text-sm'>
+                  <thead className='bg-white/4 text-white/75'>
+                    <tr>
+                      <HeaderCell>轮次</HeaderCell>
+                      <HeaderCell>用户说话文本</HeaderCell>
+                      <HeaderCell>智能体回复文本</HeaderCell>
+                      <HeaderCell>端到端延迟</HeaderCell>
+                      <HeaderCell>RTC 延迟</HeaderCell>
+                      <HeaderCell>AI 音频算法延迟</HeaderCell>
+                      <HeaderCell>ASR_TTLW</HeaderCell>
+                      <HeaderCell>LLM_TTFT</HeaderCell>
+                      <HeaderCell>TTS_TTFB</HeaderCell>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {report.rows.map((row) => (
+                      <tr
+                        key={`report-row-${row.turnId}`}
+                        className='border-white/6 border-t align-top'
+                      >
+                        <Cell className='whitespace-nowrap'>{`第${row.turnId}轮`}</Cell>
+                        <Cell>{row.userText}</Cell>
+                        <Cell>{row.agentText}</Cell>
+                        <Cell>{row.e2eLatencyMs}</Cell>
+                        <Cell>{row.rtcTransportMs}</Cell>
+                        <Cell>{row.algorithmProcessingMs}</Cell>
+                        <Cell>{row.asrTtlwMs}</Cell>
+                        <Cell>{row.llmTtftMs}</Cell>
+                        <Cell>{row.ttsTtfbMs}</Cell>
+                      </tr>
+                    ))}
+                    <tr className='border-white/6 border-t bg-white/4 font-semibold'>
+                      <Cell>均值</Cell>
+                      <Cell>—</Cell>
+                      <Cell>—</Cell>
+                      <Cell>{report.averages.e2eLatencyMs}</Cell>
+                      <Cell>{report.averages.rtcTransportMs}</Cell>
+                      <Cell>{report.averages.algorithmProcessingMs}</Cell>
+                      <Cell>{report.averages.asrTtlwMs}</Cell>
+                      <Cell>{report.averages.llmTtftMs}</Cell>
+                      <Cell>{report.averages.ttsTtfbMs}</Cell>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </section>
+          </>
+        )}
+      </div>
+    </main>
+  )
+}
+
+const InfoItem = (props: { label: string; value: string }) => (
+  <div className='flex flex-col gap-2'>
+    <span className='text-sm text-white/55'>{props.label}</span>
+    <span className='break-all font-medium text-base'>{props.value}</span>
+  </div>
+)
+
+const HeaderCell = (props: { children: React.ReactNode }) => (
+  <th className='whitespace-nowrap px-4 py-3 font-medium'>{props.children}</th>
+)
+
+const Cell = (props: { children: React.ReactNode; className?: string }) => (
+  <td className={cn('px-4 py-3 text-white/90', props.className)}>
+    {props.children}
+  </td>
+)
+
+function formatTimestamp(timestamp: number) {
+  return new Intl.DateTimeFormat('zh-CN', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false
+  }).format(new Date(timestamp))
+}

--- a/Web/Scenes/VoiceAgent/src/components/home/agent-card-utils.test.ts
+++ b/Web/Scenes/VoiceAgent/src/components/home/agent-card-utils.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from 'bun:test'
+import { advanceAdvancedFeatureKeyframes } from '@/components/home/agent-card-utils'
+
+describe('advanceAdvancedFeatureKeyframes', () => {
+  test('advances one step without recursively cycling through all states', () => {
+    expect(advanceAdvancedFeatureKeyframes('1,2,3')).toBe('2,3,1')
+    expect(advanceAdvancedFeatureKeyframes('2,3,1')).toBe('3,1,2')
+    expect(advanceAdvancedFeatureKeyframes('3,1,2')).toBe('1,2,3')
+  })
+
+  test('keeps unknown keyframes unchanged', () => {
+    expect(advanceAdvancedFeatureKeyframes('custom')).toBe('custom')
+  })
+})

--- a/Web/Scenes/VoiceAgent/src/components/home/agent-card-utils.ts
+++ b/Web/Scenes/VoiceAgent/src/components/home/agent-card-utils.ts
@@ -1,0 +1,15 @@
+export function advanceAdvancedFeatureKeyframes(keyframes: string) {
+  if (keyframes === '1,2,3') {
+    return '2,3,1'
+  }
+
+  if (keyframes === '2,3,1') {
+    return '3,1,2'
+  }
+
+  if (keyframes === '3,1,2') {
+    return '1,2,3'
+  }
+
+  return keyframes
+}

--- a/Web/Scenes/VoiceAgent/src/components/home/agent-card.tsx
+++ b/Web/Scenes/VoiceAgent/src/components/home/agent-card.tsx
@@ -12,6 +12,7 @@ import {
   CardActions,
   CardContent
 } from '@/components/card/base'
+import { advanceAdvancedFeatureKeyframes } from '@/components/home/agent-card-utils'
 import { LiveMetricsToggle } from '@/components/home/live-metrics-toggle'
 import { useClickAway } from '@/hooks/use-click-away'
 import { useIsDemoCalling } from '@/hooks/use-is-agent-calling'
@@ -191,18 +192,8 @@ export function AgentCardAdvancedFeatures() {
   // }, [open])
 
   useEffect(() => {
-    if (keyframes === '1,2,3') {
-      setKeyframes('2,3,1')
-    }
-
-    if (keyframes === '2,3,1') {
-      setKeyframes('3,1,2')
-    }
-
-    if (keyframes === '3,1,2') {
-      setKeyframes('1,2,3')
-    }
-  }, [keyframes])
+    setKeyframes((current) => advanceAdvancedFeatureKeyframes(current))
+  }, [])
 
   const salItem = (
     <div className='flex items-center gap-2 px-4 py-1.5'>

--- a/Web/Scenes/VoiceAgent/src/components/home/agent-card.tsx
+++ b/Web/Scenes/VoiceAgent/src/components/home/agent-card.tsx
@@ -12,6 +12,7 @@ import {
   CardActions,
   CardContent
 } from '@/components/card/base'
+import { LiveMetricsToggle } from '@/components/home/live-metrics-toggle'
 import { useClickAway } from '@/hooks/use-click-away'
 import { useIsDemoCalling } from '@/hooks/use-is-agent-calling'
 import { useIsMobile } from '@/hooks/use-mobile'
@@ -27,6 +28,7 @@ import { cn } from '@/lib/utils'
 import {
   useAgentSettingsStore,
   useGlobalStore,
+  useReportStore,
   useRTCStore,
   useUserInfoStore
 } from '@/store'
@@ -40,28 +42,32 @@ export function AgentCard(props: {
   className?: string
 }) {
   const { children, className } = props
-  const t = useTranslations()
+  const _t = useTranslations()
 
   const {
     showSidebar,
     showSALSettingSidebar,
+    showSubtitle,
     onClickSidebar,
     setShowSALSettingSidebar
   } = useGlobalStore()
   const { selectedPreset } = useAgentSettingsStore()
   const { accountUid } = useUserInfoStore()
+  const { activeSession } = useReportStore()
 
   const isSipPresetSelected =
     !!selectedPreset?.preset?.preset_type?.includes('sip_call')
   // const t = useTranslations()
   const isDemoCalling = useIsDemoCalling()
+  const showLiveMetricsToggle =
+    isDemoCalling && showSubtitle && !!activeSession?.turns.length
 
   return (
     <Card
       className={cn(
         'w-full',
         {
-          ['md:mr-3 md:w-[calc(100%-var(--ag-sidebar-width))]']: showSidebar
+          'md:mr-3 md:w-[calc(100%-var(--ag-sidebar-width))]': showSidebar
         },
         className
       )}
@@ -69,7 +75,7 @@ export function AgentCard(props: {
       <CardActions
         className={cn(
           'z-50',
-          { ['hidden']: !accountUid },
+          { hidden: !accountUid },
           {
             'max-md:flex max-md:flex-col max-md:items-end': isDemoCalling
           }
@@ -102,6 +108,7 @@ export function AgentCard(props: {
         </div>
         {!isSipPresetSelected && (
           <>
+            {showLiveMetricsToggle && <LiveMetricsToggle />}
             <AgentCardAdvancedFeatures />
             <CardAction
               key='settings'
@@ -142,7 +149,7 @@ export function AgentCardContent(props: {
 
 export function AgentCardAdvancedFeatures() {
   const t = useTranslations('roomInfo')
-  const ref = useRef<NodeJS.Timeout>(null)
+  const _ref = useRef<NodeJS.Timeout>(null)
   const isMobile = useIsMobile()
 
   const { salStatus } = useRTCStore()
@@ -150,7 +157,7 @@ export function AgentCardAdvancedFeatures() {
 
   const [open, setOpen] = useState(false)
   const [keyframes, setKeyframes] = useState<string>('1,2,3')
-  const [top, setTop] = useState<'sal' | 'vad'>('vad')
+  const [_top, _setTop] = useState<'sal' | 'vad'>('vad')
 
   const { setIsRoomInfoOpen } = useGlobalStore()
 
@@ -195,7 +202,7 @@ export function AgentCardAdvancedFeatures() {
     if (keyframes === '3,1,2') {
       setKeyframes('1,2,3')
     }
-  }, [top])
+  }, [keyframes])
 
   const salItem = (
     <div className='flex items-center gap-2 px-4 py-1.5'>
@@ -219,7 +226,7 @@ export function AgentCardAdvancedFeatures() {
     </div>
   )
 
-  const keyframesItems = keyframes.split(',').map((item) => Number(item))
+  const _keyframesItems = keyframes.split(',').map((item) => Number(item))
 
   if (isMobile) {
     return (
@@ -368,7 +375,7 @@ export function AgentCardAdvancedFeatures() {
       <div className='my-1.5'>
         <div className='border-border border-l px-2'>
           <DropdownIcon
-            className={cn('size-6', { ['rotate-180 duration-300']: open })}
+            className={cn('size-6', { 'rotate-180 duration-300': open })}
           />
         </div>
       </div>

--- a/Web/Scenes/VoiceAgent/src/components/home/agent-control.tsx
+++ b/Web/Scenes/VoiceAgent/src/components/home/agent-control.tsx
@@ -58,22 +58,27 @@ import {
   EMessageSalStatus,
   ERTCCustomEvents,
   ERTCEvents,
-  ETranscriptHelperMode,
   type IAgentTranscription,
   type IMessageSalStatus,
   type ITranscriptHelperItem,
   type IUserTranscription,
+  type TAgentTurnFinished,
   type TStateChangeEvent
 } from '@/conversational-ai-api/type'
 import {
   useIsAgentCalling,
   useIsAgentSipCalling
 } from '@/hooks/use-is-agent-calling'
+import {
+  buildLatencyReportPayload,
+  type TranscriptLikeItem
+} from '@/lib/latency-metrics'
 import { logger } from '@/lib/logger'
 import { cn } from '@/lib/utils'
 import {
   pingAgent,
   ResourceLimitError,
+  reportAgentMetrics,
   startAgent,
   stopAgent
 } from '@/services/agent'
@@ -82,6 +87,7 @@ import {
   useAgentSettingsStore,
   useChatStore,
   useGlobalStore,
+  useReportStore,
   useRTCStore,
   useUserInfoStore
 } from '@/store'
@@ -150,6 +156,14 @@ export default function AgentControl(props: { className?: string }) {
     sipStatus
   } = useSipStore()
   const { setHistory, clearHistory } = useChatStore()
+  const {
+    startSession,
+    upsertTurn,
+    syncTranscript,
+    finalizeActiveSession,
+    markUploaded,
+    clearActiveSession
+  } = useReportStore()
   const { accountUid, clearUserInfo } = useUserInfoStore()
 
   const sipStatusRef = React.useRef<NodeJS.Timeout | null>(null)
@@ -211,6 +225,10 @@ export default function AgentControl(props: { className?: string }) {
         EConversationalAIAPIEvents.MESSAGE_SAL_STATUS,
         onMessageSalStatus
       )
+      conversationalAIAPI.on(
+        EConversationalAIAPIEvents.AGENT_TURN_FINISHED,
+        onTurnFinished
+      )
 
       conversationalAIAPI.on(
         EConversationalAIAPIEvents.TRANSCRIPT_UPDATED,
@@ -227,7 +245,7 @@ export default function AgentControl(props: { className?: string }) {
       )?.preset_type
       const messageServiceMode =
         presetType?.startsWith('standard') ||
-          settings.preset_type === 'custom_private'
+        settings.preset_type === 'custom_private'
           ? 'default'
           : 'legacy'
 
@@ -352,13 +370,13 @@ export default function AgentControl(props: { className?: string }) {
         // avatar releated
         avatar: settings.avatar
           ? {
-            enable: true,
-            vendor: settings.avatar.vendor,
-            params: {
-              agora_uid: `${avatar_rtc_uid}`,
-              avatar_id: settings.avatar.avatar_id
+              enable: true,
+              vendor: settings.avatar.vendor,
+              params: {
+                agora_uid: `${avatar_rtc_uid}`,
+                avatar_id: settings.avatar.avatar_id
+              }
             }
-          }
           : undefined,
         channel: channel_name,
         agent_rtc_uid: `${agent_rtc_uid}`,
@@ -369,6 +387,14 @@ export default function AgentControl(props: { className?: string }) {
       startAgentAbortControllerRef.current = abortController
       const res = await startAgent(payload, abortController)
       updateAgentId(res.agent_id)
+      startSession({
+        agentId: res.agent_id,
+        channel: channel_name,
+        presetName: settings.preset_name,
+        presetDisplayName:
+          selectedPreset?.preset.display_name || settings.preset_name,
+        callStartAt: Date.now()
+      })
 
       setConversationTimerEndTimestamp(Date.now() + conversationDuration * 1000)
       setHeartBeat()
@@ -522,8 +548,13 @@ export default function AgentControl(props: { className?: string }) {
         logger.log('clearAndExit unauthorizedError')
         toast.error(tLogin('unauthorizedError'))
       }
+    } finally {
+      await uploadLatencyReport()
     }
   }
+
+  const clearAndExitRef = React.useRef(clearAndExit)
+  clearAndExitRef.current = clearAndExit
 
   // SIP
 
@@ -562,6 +593,14 @@ export default function AgentControl(props: { className?: string }) {
       updateSipStatus(ESipStatus.CALLING)
       console.log('startSipService res', res)
       updateAgentId(res.agent_id)
+      startSession({
+        agentId: res.agent_id,
+        channel: channel_name,
+        presetName: sipPreset?.preset_name || settings.preset_name,
+        presetDisplayName:
+          selectedPreset?.preset.display_name || sipPreset?.preset_name || '',
+        callStartAt: Date.now()
+      })
     } catch (error: unknown) {
       logger.error({ error }, 'startSipService error')
       console.log('startSipService error', (error as Error).message)
@@ -629,6 +668,10 @@ export default function AgentControl(props: { className?: string }) {
       EConversationalAIAPIEvents.TRANSCRIPT_UPDATED,
       onTextChanged
     )
+    conversationalAIAPI.on(
+      EConversationalAIAPIEvents.AGENT_TURN_FINISHED,
+      onTurnFinished
+    )
 
     conversationalAIAPI.subscribeMessage(channel_name)
     await rtmHelper.join(channel_name)
@@ -655,6 +698,7 @@ export default function AgentControl(props: { className?: string }) {
     startAgentAbortControllerRef.current = null
     clearCommon()
     updateChannelName()
+    await uploadLatencyReport()
   }
 
   const onLocalTracksChanged = (tracks: IUserTracks) => {
@@ -735,7 +779,7 @@ export default function AgentControl(props: { className?: string }) {
     if (data.curState === 'RECONNECTING' && data.revState === 'CONNECTED') {
       logger.info(
         'agent is listening -> user is offline(due to network issue) temporarily' +
-        '[onConnectionStateChange]'
+          '[onConnectionStateChange]'
       )
       toast.warning(tAgent('tmpDisconnected'))
       updateAgentStatus(EConnectionStatus.RECONNECTING)
@@ -747,7 +791,7 @@ export default function AgentControl(props: { className?: string }) {
     if (data.curState === 'CONNECTED' && data.revState === 'RECONNECTING') {
       logger.info(
         'agent is listening -> user is online again(in short time)' +
-        '[onConnectionStateChange]'
+          '[onConnectionStateChange]'
       )
       toast.success(tAgent('agentReconnected'))
       updateAgentStatus(EConnectionStatus.CONNECTED)
@@ -778,6 +822,18 @@ export default function AgentControl(props: { className?: string }) {
   ) => {
     logger.info({ history }, 'onTextChanged')
     setHistory(history)
+    syncTranscript(
+      history.map((item) => ({
+        turn_id: item.turn_id,
+        uid: item.uid,
+        text: item.text
+      })) as TranscriptLikeItem[]
+    )
+  }
+
+  const onTurnFinished = (_agentUserId: string, turn: TAgentTurnFinished) => {
+    logger.info({ turn }, 'onTurnFinished')
+    upsertTurn(turn)
   }
 
   const onAgentStateChangedLegacy = (state: EAgentState) => {
@@ -815,6 +871,34 @@ export default function AgentControl(props: { className?: string }) {
       }
     } else {
       updateSalStatus(ESALSettingsMode.OFF)
+    }
+  }
+
+  const uploadLatencyReport = async () => {
+    const session = finalizeActiveSession()
+    if (!session?.agentId || session.turns.length === 0) {
+      clearActiveSession()
+      return
+    }
+
+    try {
+      const payload = buildLatencyReportPayload({
+        agentId: session.agentId,
+        channel: session.channel,
+        presetName: session.presetName,
+        presetDisplayName: session.presetDisplayName,
+        callStartAt: session.callStartAt,
+        turns: session.turns,
+        transcriptByTurnId: session.transcriptByTurnId
+      })
+      const res = await reportAgentMetrics(payload, {
+        devMode: isDevMode
+      })
+      markUploaded(session.agentId, res.data?.uploaded_at)
+    } catch (error) {
+      logger.error({ error, agentId: session.agentId }, 'uploadLatencyReport')
+    } finally {
+      clearActiveSession()
     }
   }
 
@@ -871,7 +955,7 @@ export default function AgentControl(props: { className?: string }) {
   // listen to global events
   React.useEffect(() => {
     const handleStopAgent = () => {
-      clearAndExit()
+      void clearAndExitRef.current()
     }
 
     window.addEventListener('stop-agent', handleStopAgent)
@@ -879,16 +963,15 @@ export default function AgentControl(props: { className?: string }) {
     return () => {
       window.removeEventListener('stop-agent', handleStopAgent)
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  function cleanUpSip() {
+  const cleanUpSip = React.useCallback(() => {
     if (sipStatusRef.current) {
       clearInterval(sipStatusRef.current)
       sipStatusRef.current = null
     }
     updateSipStatus(ESipStatus.IDLE)
-  }
+  }, [updateSipStatus])
 
   React.useEffect(() => {
     if (agent_id && showCallingPage) {
@@ -924,13 +1007,13 @@ export default function AgentControl(props: { className?: string }) {
     return () => {
       cleanUpSip()
     }
-  }, [agent_id, showCallingPage, updateSipStatus])
+  }, [agent_id, showCallingPage, updateSipStatus, cleanUpSip])
 
   React.useEffect(() => {
     if (sipStatus === ESipStatus.CONNECTED) {
       setShowSubtitle(true)
     }
-  }, [sipStatus])
+  }, [sipStatus, setShowSubtitle])
 
   return (
     <>
@@ -1056,7 +1139,7 @@ const CompatibilityCheck = () => {
       setShowCompatibilityDialog(true)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [setIsRTCCompatible, setShowCompatibilityDialog])
 
   return (
     <Dialog

--- a/Web/Scenes/VoiceAgent/src/components/home/agent-setting/form-custom-private.tsx
+++ b/Web/Scenes/VoiceAgent/src/components/home/agent-setting/form-custom-private.tsx
@@ -19,7 +19,7 @@ import {
   FormField,
   FormItem,
   FormLabel,
-  FormMessage,
+  FormMessage
 } from '@/components/ui/form'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -28,7 +28,7 @@ import {
   SelectContent,
   SelectItem,
   SelectTrigger,
-  SelectValue,
+  SelectValue
 } from '@/components/ui/select'
 import { Separator } from '@/components/ui/separator'
 import { Switch } from '@/components/ui/switch'
@@ -36,19 +36,19 @@ import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
-  TooltipTrigger,
+  TooltipTrigger
 } from '@/components/ui/tooltip'
 import {
   CONSOLE_IMG_HEIGHT,
   CONSOLE_IMG_URL,
   CONSOLE_IMG_WIDTH,
   CONSOLE_URL,
-  publicAgentSettingSchema,
+  publicAgentSettingSchema
 } from '@/constants'
 import { ETranscriptHelperMode } from '@/conversational-ai-api/type'
 import { useIsDemoCalling } from '@/hooks/use-is-agent-calling'
 import { cn, isCN } from '@/lib/utils'
-import { useAgentSettingsStore, useGlobalStore } from '@/store'
+import { useAgentSettingsStore, useGlobalStore, useReportStore } from '@/store'
 import type { TAgentSettings } from '@/store/agent'
 import { useRTCStore } from '@/store/rtc'
 import type { IAgentPreset } from '@/type/agent'
@@ -64,10 +64,11 @@ export function CustomPrivateSettingsForm(props: {
     updateSettings,
     transcriptionRenderMode,
     updateTranscriptionRenderMode,
-    updateFormSetValue,
+    updateFormSetValue
   } = useAgentSettingsStore()
 
   const { isDevMode, setShowSALSettingSidebar } = useGlobalStore()
+  const { sessionsByAgentId } = useReportStore()
 
   const { remote_rtc_uid } = useRTCStore()
 
@@ -75,7 +76,7 @@ export function CustomPrivateSettingsForm(props: {
 
   const settingsForm = useForm({
     resolver: zodResolver(publicAgentSettingSchema),
-    defaultValues: settings,
+    defaultValues: settings
   })
 
   const disableFormMemo = useIsDemoCalling()
@@ -96,7 +97,17 @@ export function CustomPrivateSettingsForm(props: {
       updateSettings(value as TAgentSettings)
     })
     return () => subscription.unsubscribe()
-  }, [settingsForm, updateSettings, settings])
+  }, [settingsForm, updateSettings])
+
+  const latestReportSession = React.useMemo(() => {
+    return Object.values(sessionsByAgentId)
+      .filter((session) => session.presetName === settings.preset_name)
+      .sort(
+        (a, b) =>
+          Math.max(b.uploadedAt || 0, b.callStartAt) -
+          Math.max(a.uploadedAt || 0, a.callStartAt)
+      )[0]
+  }, [sessionsByAgentId, settings.preset_name])
 
   return (
     <Form {...settingsForm}>
@@ -104,13 +115,13 @@ export function CustomPrivateSettingsForm(props: {
         <InnerCard>
           <FormField
             control={settingsForm.control}
-            name="asr.language"
+            name='asr.language'
             render={({ field }) => (
               <FormItem>
-                <div className="flex items-center justify-between gap-3">
-                  <Label className="w-1/3">{t('asr.language')}</Label>
+                <div className='flex items-center justify-between gap-3'>
+                  <Label className='w-1/3'>{t('asr.language')}</Label>
                   <Select value={field.value} disabled>
-                    <SelectTrigger className="w-2/3" disabled={disableFormMemo}>
+                    <SelectTrigger className='w-2/3' disabled={disableFormMemo}>
                       <SelectValue placeholder={t('asr.language')} />
                     </SelectTrigger>
                     <SelectContent>
@@ -126,28 +137,28 @@ export function CustomPrivateSettingsForm(props: {
           />
         </InnerCard>
         <InnerCard>
-          <h3 className="">{t('advanced_features.title')}</h3>
+          <h3 className=''>{t('advanced_features.title')}</h3>
           <Separator />
           <FormField
             control={settingsForm.control}
-            name="advanced_features.enable_aivad"
+            name='advanced_features.enable_aivad'
             render={({ field }) => (
               <TooltipProvider>
                 <FormItem>
-                  <div className="flex items-center justify-between gap-2">
+                  <div className='flex items-center justify-between gap-2'>
                     <FormLabel
                       className={cn('flex items-center gap-1 py-2 font-normal')}
                     >
                       {t.rich('advanced_features.enable_aivad.title', {
                         label: (chunks) => (
-                          <span className="text-icontext">{chunks}</span>
-                        ),
+                          <span className='text-icontext'>{chunks}</span>
+                        )
                       })}
                       <Tooltip>
                         <TooltipTrigger asChild>
-                          <FilledTooltipIcon className="inline size-4" />
+                          <FilledTooltipIcon className='inline size-4' />
                         </TooltipTrigger>
-                        <TooltipContent className="max-w-xs">
+                        <TooltipContent className='max-w-xs'>
                           <p>
                             {t('advanced_features.enable_aivad.description')}
                           </p>
@@ -167,8 +178,8 @@ export function CustomPrivateSettingsForm(props: {
               </TooltipProvider>
             )}
           />
-          <div className="flex items-center justify-between gap-2 py-2">
-            <Label className="font-normal">
+          <div className='flex items-center justify-between gap-2 py-2'>
+            <Label className='font-normal'>
               {t('advanced_features.enable_sal.title')}
             </Label>
             <motion.div
@@ -188,11 +199,11 @@ export function CustomPrivateSettingsForm(props: {
               {t(
                 `advanced_features.enable_sal.${settings.advanced_features.enable_sal ? (settings.sal?.sample_urls?.[remote_rtc_uid] ? 'manual' : 'autoLearning') : 'off'}`
               )}
-              <ChevronRight className="size-5" />
+              <ChevronRight className='size-5' />
             </motion.div>
           </div>
-          <div className="flex items-center justify-between gap-2">
-            <Label className="font-normal">
+          <div className='flex items-center justify-between gap-2'>
+            <Label className='font-normal'>
               {t('transcription.render-mode')}
             </Label>
             <Select
@@ -200,7 +211,7 @@ export function CustomPrivateSettingsForm(props: {
               onValueChange={updateTranscriptionRenderMode}
               disabled={disableFormMemo}
             >
-              <SelectTrigger className="w-fit min-w-[150px]">
+              <SelectTrigger className='w-fit min-w-[150px]'>
                 <SelectValue>
                   {t(`transcription.${transcriptionRenderMode}.title`)}
                 </SelectValue>
@@ -208,15 +219,15 @@ export function CustomPrivateSettingsForm(props: {
               <SelectContent>
                 {(isCN
                   ? [
-                    ETranscriptHelperMode.WORD,
-                    ETranscriptHelperMode.CHUNK,
-                    ETranscriptHelperMode.TEXT,
-                  ]
+                      ETranscriptHelperMode.WORD,
+                      ETranscriptHelperMode.CHUNK,
+                      ETranscriptHelperMode.TEXT
+                    ]
                   : [ETranscriptHelperMode.WORD, ETranscriptHelperMode.TEXT]
                 ).map((item) => (
                   <SelectItem key={`render-mode-${item}`} value={item}>
                     <div>{t(`transcription.${item}.title`)}</div>
-                    <div className="text-icontext-disabled">
+                    <div className='text-icontext-disabled'>
                       {t(`transcription.${item}.description`)}
                     </div>
                   </SelectItem>
@@ -226,38 +237,38 @@ export function CustomPrivateSettingsForm(props: {
           </div>
         </InnerCard>
 
-        <NextLink href={CONSOLE_URL} target="_blank">
+        <NextLink href={CONSOLE_URL} target='_blank'>
           <NextImage
             src={CONSOLE_IMG_URL}
-            alt="console-img"
+            alt='console-img'
             width={CONSOLE_IMG_WIDTH}
             height={CONSOLE_IMG_HEIGHT}
-            className="mt-6 h-fit w-full rounded-lg"
+            className='mt-6 h-fit w-full rounded-lg'
           />
         </NextLink>
 
         {isDevMode && (
-          <InnerCard className="mt-6">
-            <h3 className="">DEV MODE</h3>
+          <InnerCard className='mt-6'>
+            <h3 className=''>DEV MODE</h3>
             <Separator />
             <FormField
               control={settingsForm.control}
-              name="graph_id"
+              name='graph_id'
               render={({ field }) => (
                 <FormItem>
-                  <div className="flex items-center justify-between gap-2">
-                    <FormLabel className="text-icontext">Graph ID</FormLabel>
+                  <div className='flex items-center justify-between gap-2'>
+                    <FormLabel className='text-icontext'>Graph ID</FormLabel>
                     <FormControl>
                       <Input
                         disabled={disableFormMemo}
-                        placeholder="1.3.0-12-ga443e7e"
+                        placeholder='1.3.0-12-ga443e7e'
                         {...field}
                         value={field.value || ''}
                         onChange={(e) => {
                           const value = e.target.value
                           field.onChange(value || undefined)
                         }}
-                        className="w-[200px]"
+                        className='w-[200px]'
                       />
                     </FormControl>
                   </div>
@@ -267,22 +278,22 @@ export function CustomPrivateSettingsForm(props: {
             />
             <FormField
               control={settingsForm.control}
-              name="preset"
+              name='preset'
               render={({ field }) => (
                 <FormItem>
-                  <div className="flex items-center justify-between gap-2">
-                    <FormLabel className="text-icontext">Preset</FormLabel>
+                  <div className='flex items-center justify-between gap-2'>
+                    <FormLabel className='text-icontext'>Preset</FormLabel>
                     <FormControl>
                       <Input
                         disabled={disableFormMemo}
-                        placeholder="sess_ctrl_dev"
+                        placeholder='sess_ctrl_dev'
                         {...field}
                         value={field.value || ''}
                         onChange={(e) => {
                           const value = e.target.value
                           field.onChange(value || undefined)
                         }}
-                        className="w-[200px]"
+                        className='w-[200px]'
                       />
                     </FormControl>
                   </div>
@@ -293,10 +304,30 @@ export function CustomPrivateSettingsForm(props: {
           </InnerCard>
         )}
 
-        <div className="mt-4 flex flex-col items-center justify-center">
+        {!disableFormMemo && (
+          <div className='flex items-center justify-between gap-2'>
+            <Label className='font-normal'>{t('report.title')}</Label>
+            {latestReportSession?.agentId ? (
+              <NextLink
+                href={`/reports/${latestReportSession.agentId}`}
+                className='flex items-center gap-1 text-[10px] text-icontext md:text-xs'
+              >
+                <span>{t('report.view')}</span>
+                <ChevronRight className='size-5' />
+              </NextLink>
+            ) : (
+              <div className='flex items-center gap-1 text-[10px] text-icontext-disabled md:text-xs'>
+                <span>{t('report.empty')}</span>
+                <ChevronRight className='size-5' />
+              </div>
+            )}
+          </div>
+        )}
+
+        <div className='mt-4 flex flex-col items-center justify-center'>
           <div>V{packageJson.version}</div>
           {process.env.NEXT_PUBLIC_COMMIT_SHA ? (
-            <p className="text-muted-foreground text-xs">
+            <p className='text-muted-foreground text-xs'>
               {`Build ${process.env.NEXT_PUBLIC_COMMIT_SHA}`}
             </p>
           ) : null}

--- a/Web/Scenes/VoiceAgent/src/components/home/agent-setting/form-demo.tsx
+++ b/Web/Scenes/VoiceAgent/src/components/home/agent-setting/form-demo.tsx
@@ -53,7 +53,7 @@ import {
 import { ETranscriptHelperMode } from '@/conversational-ai-api/type'
 import { useIsDemoCalling } from '@/hooks/use-is-agent-calling'
 import { cn, isCN } from '@/lib/utils'
-import { useAgentSettingsStore, useGlobalStore } from '@/store'
+import { useAgentSettingsStore, useGlobalStore, useReportStore } from '@/store'
 import type { TAgentSettings } from '@/store/agent'
 import { useRTCStore } from '@/store/rtc'
 import type { IAgentPreset } from '@/type/agent'
@@ -81,6 +81,7 @@ export function AgentSettingsForm(props: {
     setIsPresetDigitalReminderIgnored,
     setShowSALSettingSidebar
   } = useGlobalStore()
+  const { sessionsByAgentId } = useReportStore()
 
   const { remote_rtc_uid } = useRTCStore()
 
@@ -131,7 +132,7 @@ export function AgentSettingsForm(props: {
       aivad_target_presets
     ]
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedPreset, settingsForm.watch('asr.language')])
+  }, [selectedPreset, settingsForm.watch])
 
   const { advanced_features_enable_sal, is_support_sal } = React.useMemo(() => {
     return {
@@ -149,7 +150,7 @@ export function AgentSettingsForm(props: {
       updateSettings(value as TAgentSettings)
     })
     return () => subscription.unsubscribe()
-  }, [settingsForm, updateSettings, settings])
+  }, [settingsForm, updateSettings])
 
   React.useEffect(() => {
     // !SPECIAL CASE[independent]
@@ -201,7 +202,7 @@ export function AgentSettingsForm(props: {
     aivad_enabled_by_default,
     selectedPreset,
     target_language,
-    process.env.NEXT_PUBLIC_LOCALE
+    settingsForm.setValue
   ])
 
   React.useEffect(() => {
@@ -209,7 +210,7 @@ export function AgentSettingsForm(props: {
       'advanced_features.enable_sal',
       !!advanced_features_enable_sal
     )
-  }, [advanced_features_enable_sal])
+  }, [advanced_features_enable_sal, settingsForm.setValue])
 
   React.useEffect(() => {
     if (avatarList && avatarList.length > 0) {
@@ -220,6 +221,16 @@ export function AgentSettingsForm(props: {
       }
     }
   }, [avatarList])
+
+  const latestReportSession = React.useMemo(() => {
+    return Object.values(sessionsByAgentId)
+      .filter((session) => session.presetName === selectedPreset.name)
+      .sort(
+        (a, b) =>
+          Math.max(b.uploadedAt || 0, b.callStartAt) -
+          Math.max(a.uploadedAt || 0, a.callStartAt)
+      )[0]
+  }, [selectedPreset.name, sessionsByAgentId])
 
   return (
     <Form {...settingsForm}>
@@ -288,11 +299,11 @@ export function AgentSettingsForm(props: {
                           field.onChange(value)
                         }
                       }}
-                    //   disabled={
-                    //     disableFormMemo ||
-                    //     settingsForm.watch('preset_name') !==
-                    //       EAgentPresetMode.CUSTOM
-                    //   }
+                      //   disabled={
+                      //     disableFormMemo ||
+                      //     settingsForm.watch('preset_name') !==
+                      //       EAgentPresetMode.CUSTOM
+                      //   }
                     >
                       <SelectTrigger
                         className='w-2/3'
@@ -429,10 +440,10 @@ export function AgentSettingsForm(props: {
               <SelectContent>
                 {(isCN
                   ? [
-                    ETranscriptHelperMode.WORD,
-                    ETranscriptHelperMode.CHUNK,
-                    ETranscriptHelperMode.TEXT
-                  ]
+                      ETranscriptHelperMode.WORD,
+                      ETranscriptHelperMode.CHUNK,
+                      ETranscriptHelperMode.TEXT
+                    ]
                   : [ETranscriptHelperMode.WORD, ETranscriptHelperMode.TEXT]
                 ).map((item) => (
                   <SelectItem key={`render-mode-${item}`} value={item}>
@@ -461,18 +472,6 @@ export function AgentSettingsForm(props: {
           <InnerCard className='mt-6'>
             <h3 className=''>DEV MODE</h3>
             <Separator />
-            <div className='flex items-center justify-between gap-2'>
-              <FormLabel className='text-icontext'>
-                {isCN ? '渲染模式回退' : 'Render mode fallback'}
-              </FormLabel>
-              <FormControl>
-                <Switch
-                  disabled={disableFormMemo}
-                  checked={enableRenderModeFallback}
-                  onCheckedChange={updateEnableRenderModeFallback}
-                />
-              </FormControl>
-            </div>
             <FormField
               control={settingsForm.control}
               name='graph_id'
@@ -523,7 +522,39 @@ export function AgentSettingsForm(props: {
                 </FormItem>
               )}
             />
+            <div className='flex items-center justify-between gap-2'>
+              <FormLabel className='text-icontext'>
+                {isCN ? '渲染模式回退' : 'Render mode fallback'}
+              </FormLabel>
+              <FormControl>
+                <Switch
+                  disabled={disableFormMemo}
+                  checked={enableRenderModeFallback}
+                  onCheckedChange={updateEnableRenderModeFallback}
+                />
+              </FormControl>
+            </div>
           </InnerCard>
+        )}
+
+        {!disableFormMemo && (
+          <div className='flex items-center justify-between gap-2'>
+            <Label className='font-normal'>{t('report.title')}</Label>
+            {latestReportSession?.agentId ? (
+              <NextLink
+                href={`/reports/${latestReportSession.agentId}`}
+                className='flex items-center gap-1 text-[10px] text-icontext md:text-xs'
+              >
+                <span>{t('report.view')}</span>
+                <ChevronRight className='size-5' />
+              </NextLink>
+            ) : (
+              <div className='flex items-center gap-1 text-[10px] text-icontext-disabled md:text-xs'>
+                <span>{t('report.empty')}</span>
+                <ChevronRight className='size-5' />
+              </div>
+            )}
+          </div>
         )}
 
         <div className='mt-4 flex flex-col items-center justify-center'>

--- a/Web/Scenes/VoiceAgent/src/components/home/live-metrics-toggle.tsx
+++ b/Web/Scenes/VoiceAgent/src/components/home/live-metrics-toggle.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import { useTranslations } from 'next-intl'
+import { cn } from '@/lib/utils'
+import { useGlobalStore, useReportStore } from '@/store'
+
+export const LiveMetricsToggle = () => {
+  const t = useTranslations('report')
+  const { showLiveMetrics, setShowLiveMetrics, showSubtitle } = useGlobalStore()
+  const { activeSession } = useReportStore()
+
+  if (!showSubtitle || !activeSession?.turns.length) {
+    return null
+  }
+
+  return (
+    <button
+      type='button'
+      onClick={() => setShowLiveMetrics(!showLiveMetrics)}
+      className='pointer-events-auto flex h-9 items-center gap-2 rounded-[8px] border border-line bg-fill-popover px-[9px] text-icontext-hover text-sm'
+    >
+      <span className='whitespace-nowrap'>{t('realtime')}</span>
+      <span
+        className={cn(
+          'relative flex h-5 w-8 items-center rounded-full p-[2px] transition-colors',
+          showLiveMetrics ? 'bg-brand-light' : 'bg-[#5b606b]'
+        )}
+      >
+        <span
+          className={cn(
+            'block h-4 w-4 rounded-full bg-white shadow-sm transition-transform',
+            showLiveMetrics ? 'translate-x-3' : 'translate-x-0'
+          )}
+        />
+      </span>
+    </button>
+  )
+}

--- a/Web/Scenes/VoiceAgent/src/components/home/subtitle.tsx
+++ b/Web/Scenes/VoiceAgent/src/components/home/subtitle.tsx
@@ -2,7 +2,7 @@
 
 import { ChevronDownIcon, CircleAlertIcon, RotateCcwIcon } from 'lucide-react'
 import NextImage from 'next/image'
-import { useTranslations } from 'next-intl'
+import { useLocale, useTranslations } from 'next-intl'
 import * as React from 'react'
 import { toast } from 'sonner'
 import {
@@ -27,12 +27,17 @@ import {
   type IUserTranscription
 } from '@/conversational-ai-api/type'
 import { useAutoScroll } from '@/hooks/use-auto-scroll'
+import {
+  buildLatencySummary,
+  type MessageLatencyInfo
+} from '@/lib/latency-metrics'
 import { cn, genUUID } from '@/lib/utils'
 import { useAgentPresets } from '@/services/agent'
 import {
   useAgentSettingsStore,
   useChatStore,
   useGlobalStore,
+  useReportStore,
   useRTCStore,
   // useRTCStore,
   useUserInfoStore
@@ -47,8 +52,9 @@ export default function SubTitle(props: { className?: string }) {
   const scrollAreaRef = React.useRef<HTMLDivElement>(null)
   const isAutoScrollEnabledRef = React.useRef(true)
 
-  const { isDevMode } = useGlobalStore()
+  const { isDevMode, showLiveMetrics } = useGlobalStore()
   const { history, userInputHistory } = useChatStore()
+  const { activeSession } = useReportStore()
   const { accountUid } = useUserInfoStore()
   const { data: remotePresets = [] } = useAgentPresets({
     devMode: isDevMode,
@@ -58,11 +64,24 @@ export default function SubTitle(props: { className?: string }) {
   // const { remote_rtc_uid } = useRTCStore()
   const { abort, reset } = useAutoScroll(scrollAreaRef)
 
+  const latencySummaryByTurnId = React.useMemo(() => {
+    return new Map(
+      (activeSession?.turns || []).map((turn) => [
+        turn.turnId,
+        buildLatencySummary(turn)
+      ])
+    )
+  }, [activeSession?.turns])
+
   const presetSelected = React.useMemo(() => {
     return remotePresets.find((preset) => preset.name === settings.preset_name)
   }, [remotePresets, settings.preset_name])
 
-  const chatHistory = transcription2subtitle(history, userInputHistory)
+  const chatHistory = transcription2subtitle(
+    history,
+    userInputHistory,
+    latencySummaryByTurnId
+  )
 
   const handleScrollDownClick = () => {
     if (scrollAreaRef.current) {
@@ -124,7 +143,7 @@ export default function SubTitle(props: { className?: string }) {
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [abort, getIsAtBottom, getIsScrollable, reset])
 
   return (
     <div className={cn('relative backdrop-blur-lg', className)}>
@@ -146,6 +165,9 @@ export default function SubTitle(props: { className?: string }) {
                       : presetSelected?.display_name
                   }
                   status={item.status}
+                  latencyMetrics={
+                    showLiveMetrics ? item.latencyMetrics : undefined
+                  }
                   className={cn({
                     hidden: item.content === ''
                   })}
@@ -194,6 +216,7 @@ const ChatItem = React.forwardRef<
     children?: React.ReactNode
     label?: string | React.ReactNode
     status?: ETurnStatus
+    latencyMetrics?: MessageLatencyInfo
   }
 >((props, ref) => {
   const {
@@ -202,7 +225,8 @@ const ChatItem = React.forwardRef<
     type = EChatItemType.USER,
     children,
     label,
-    status
+    status,
+    latencyMetrics
   } = props
 
   const { settings } = useAgentSettingsStore()
@@ -221,7 +245,7 @@ const ChatItem = React.forwardRef<
       className={cn(
         'my-2 w-full text-icontext text-sm',
         'flex flex-col gap-2',
-        { ['items-end']: type === EChatItemType.USER },
+        { 'items-end': type === EChatItemType.USER },
         className
       )}
     >
@@ -255,8 +279,8 @@ const ChatItem = React.forwardRef<
           'rounded-md py-2',
           'h-fit w-fit max-w-[80%]',
           {
-            ['bg-block-4 px-4']: type === EChatItemType.USER,
-            ['text-right']: shouldAlignRightMemo
+            'bg-block-4 px-4': type === EChatItemType.USER,
+            'text-right': shouldAlignRightMemo
           },
           contentClassName
         )}
@@ -271,6 +295,9 @@ const ChatItem = React.forwardRef<
           <ChatInterruptIcon className='size-4' />
           <span className='text-icontext text-xs'>{t('interrupted')}</span>
         </div>
+      )}
+      {type === EChatItemType.AGENT && latencyMetrics && (
+        <ChatLatencyMetrics metrics={latencyMetrics} />
       )}
     </div>
   )
@@ -389,6 +416,7 @@ export type TRemoteTranscription = {
 
   status: ETurnStatus
   content: string
+  latencyMetrics?: MessageLatencyInfo
 }
 export type TLocalUserInputImage = {
   identifier: 'local-user-input-image'
@@ -410,7 +438,8 @@ const transcription2subtitle = (
   remoteTranscriptionList: ITranscriptHelperItem<
     Partial<IUserTranscription | IAgentTranscription>
   >[],
-  userInputHistory?: ILocalImageTranscription[]
+  userInputHistory?: ILocalImageTranscription[],
+  latencySummaryByTurnId?: Map<number, MessageLatencyInfo>
 ): TSubtitleItem[] => {
   const sortedRemoteTranscriptionList: TRemoteTranscription[] =
     remoteTranscriptionList
@@ -433,7 +462,11 @@ const transcription2subtitle = (
         type: Number(item.uid) === 0 ? EChatItemType.USER : EChatItemType.AGENT,
         timestamp: item._time,
         status: item.status,
-        content: item.text.trim()
+        content: item.text.trim(),
+        latencyMetrics:
+          Number(item.uid) === 0
+            ? undefined
+            : latencySummaryByTurnId?.get(item.turn_id)
       }))
   const sortedUserInputHistory: TLocalUserInputImage[] = (
     userInputHistory || []
@@ -482,6 +515,36 @@ const transcription2subtitle = (
   }
 
   return mergedItems
+}
+
+const ChatLatencyMetrics = (props: { metrics: MessageLatencyInfo }) => {
+  const { metrics } = props
+  const locale = useLocale()
+
+  const items = [
+    [locale === 'zh-CN' ? '端到端' : 'E2E', metrics.e2eLatencyMs],
+    ['RTC', metrics.rtcTransportMs],
+    ['ASR', metrics.asrTtlwMs],
+    ['LLM', metrics.llmTtftMs],
+    ['TTS', metrics.ttsTtfbMs]
+  ] as const
+
+  return (
+    <div className='flex flex-wrap items-center gap-2.5 px-4 text-[12px] leading-[14px]'>
+      <span className='rounded-full bg-brand-white-0 px-1.5 py-px text-icontext-disabled'>
+        {`#${metrics.turnId}`}
+      </span>
+      {items.map(([label, value]) => (
+        <span
+          key={`${label}-${value}`}
+          className='flex items-center whitespace-nowrap'
+        >
+          <span className='text-icontext-disabled'>{`${label}:`}</span>
+          <span className='text-brand-main'>{`${value}ms`}</span>
+        </span>
+      ))}
+    </div>
+  )
 }
 
 function useObjectURL(file?: File | Blob) {

--- a/Web/Scenes/VoiceAgent/src/constants/agent/schema.test.ts
+++ b/Web/Scenes/VoiceAgent/src/constants/agent/schema.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  agentPresetSchema,
+  localStartAgentPropertiesSchema
+} from '@/constants/agent/schema'
+
+describe('agent schema sync with latest api contract', () => {
+  test('parses pause_state_enabled_by_default in preset languages', () => {
+    const preset = agentPresetSchema.parse({
+      name: 'intelligent_assistant',
+      display_name: '智能助手',
+      preset_type: 'standard',
+      support_languages: [
+        {
+          language_code: 'zh-CN',
+          language_name: '中文',
+          aivad_supported: true,
+          aivad_enabled_by_default: true,
+          pause_state_enabled_by_default: false
+        }
+      ]
+    })
+
+    expect(preset.support_languages?.[0]).toEqual({
+      language_code: 'zh-CN',
+      language_name: '中文',
+      aivad_supported: true,
+      aivad_enabled_by_default: true,
+      pause_state_enabled_by_default: false
+    })
+  })
+
+  test('parses top-level app_feature in local start settings', () => {
+    const payload = localStartAgentPropertiesSchema.parse({
+      channel: 'demo',
+      agent_rtc_uid: 'agent-uid',
+      remote_rtc_uids: ['user-uid'],
+      preset_name: 'intelligent_assistant',
+      asr: {
+        language: 'zh-CN'
+      },
+      advanced_features: {
+        enable_rtm: true,
+        enable_sal: false
+      },
+      parameters: {
+        audio_scenario: 'default'
+      },
+      app_feature: {
+        enable_aivad: true,
+        pause_state_enabled: false,
+        enable_local_bvc: true
+      }
+    })
+
+    expect(payload.app_feature).toEqual({
+      enable_aivad: true,
+      pause_state_enabled: false,
+      enable_local_bvc: true
+    })
+  })
+})

--- a/Web/Scenes/VoiceAgent/src/constants/agent/schema.ts
+++ b/Web/Scenes/VoiceAgent/src/constants/agent/schema.ts
@@ -28,6 +28,26 @@ export const agentAdvancedFeaturesSchema = z
   })
   .describe('Advanced Features')
 
+export const agentAppFeatureSchema = z
+  .object({
+    enable_aivad: z
+      .boolean()
+      .describe('Enable AIVAD')
+      .optional()
+      .default(false),
+    pause_state_enabled: z
+      .boolean()
+      .describe('Enable Pause State')
+      .optional()
+      .default(false),
+    enable_local_bvc: z
+      .boolean()
+      .describe('Enable Local BVC')
+      .optional()
+      .default(true)
+  })
+  .describe('App Feature')
+
 export const agentPresetLLMStyleConfigSchema = z.object({
   display_name: z.string(),
   style: z.string().min(1),
@@ -66,7 +86,8 @@ export const agentPresetSchema = z.object({
         language_code: z.string().optional(),
         language_name: z.string().optional(),
         aivad_supported: z.boolean().optional(),
-        aivad_enabled_by_default: z.boolean().optional()
+        aivad_enabled_by_default: z.boolean().optional(),
+        pause_state_enabled_by_default: z.boolean().optional()
       })
     )
     .optional(),
@@ -111,6 +132,11 @@ export const publicAgentSettingSchema = z.object({
     .describe('ASR')
     .optional(),
   advanced_features: agentAdvancedFeaturesSchema,
+  app_feature: agentAppFeatureSchema.default({
+    enable_aivad: false,
+    pause_state_enabled: false,
+    enable_local_bvc: true
+  }),
   sal: z
     .object({
       sal_mode: z.literal('locking'),
@@ -167,6 +193,11 @@ export const opensourceAgentSettingSchema = z.object({
     })
     .describe('ASR'),
   advanced_features: agentAdvancedFeaturesSchema.optional(),
+  app_feature: agentAppFeatureSchema.default({
+    enable_aivad: false,
+    pause_state_enabled: false,
+    enable_local_bvc: true
+  }),
   llm: z
     .object({
       url: z.string().url().describe('LLM URL'),
@@ -208,6 +239,11 @@ export const opensourceAgentSettingSchema = z.object({
 })
 
 export const opensourceAgentFormSchema = z.object({
+  enable_render_mode_fallback: z
+    .boolean()
+    .describe('Allow Subtitle Fallback')
+    .optional()
+    .default(true),
   asr: z
     .object({
       language: z
@@ -216,8 +252,18 @@ export const opensourceAgentFormSchema = z.object({
         .describe('Language')
     })
     .describe('ASR'),
+  enable_local_bvc: z
+    .boolean()
+    .describe('Enable Local BVC')
+    .optional()
+    .default(true),
   enable_bhvs: z.boolean().describe('Enable BHVS').optional().default(true),
   enable_aivad: z.boolean().describe('Enable AIVAD').optional().default(false),
+  pause_state_enabled: z
+    .boolean()
+    .describe('Enable Pause State')
+    .optional()
+    .default(false),
   enable_rtm: z.boolean().describe('Enable RTM').optional().default(true),
   enable_sal: z.boolean().describe('Enable SAL').optional().default(false),
   llm: z
@@ -272,7 +318,7 @@ export const localStartAgentPropertiesSchema =
           params: z
             .object({
               agora_uid: z.string().describe('Agora UID'),
-              avatar_id: z.string().describe('Avatar ID')
+              avatar_id: z.string().describe('Avatar ID').optional()
             })
             .describe('Avatar Params')
             .optional()

--- a/Web/Scenes/VoiceAgent/src/constants/api/index.ts
+++ b/Web/Scenes/VoiceAgent/src/constants/api/index.ts
@@ -27,6 +27,9 @@ export const API_AGENT_STOP = `${API_AGENT}/stop`
 export const API_AGENT_PRESETS = `${API_AGENT}/presets`
 export const API_AGENT_PING = `${API_AGENT}/ping`
 export const API_AGENT_CUSTOM_PRESET = `${API_AGENT}/customPresets/search`
+export const API_AGENT_METRICS_REPORT = `${API_AGENT}/metrics/report`
+export const API_AGENT_METRICS = (agentId: string) =>
+  `${API_AGENT}/metrics/${agentId}`
 
 export const API_AUTH_TOKEN = `/api/sso/login`
 export const API_USER_INFO = '/api/sso/userInfo'
@@ -46,6 +49,10 @@ export const REMOTE_CONVOAI_AGENT_PRESETS = '/convoai/v5/presets/list'
 export const REMOTE_CONVOAI_AGENT_START = '/convoai/v5/start'
 export const REMOTE_CONVOAI_AGENT_STOP = '/convoai/v5/stop'
 export const REMOTE_CONVOAI_AGENT_PING = '/convoai/v5/ping'
+export const REMOTE_CONVOAI_AGENT_METRICS_REPORT =
+  '/convoai/v5/agent/metrics/report'
+export const REMOTE_CONVOAI_AGENT_METRICS = (agentId: string) =>
+  `/convoai/v5/agent/metrics/${agentId}`
 export const REMOTE_CONVOAI_SIP_START = '/convoai/v5/call'
 export const REMOTE_CONVOAI_SIP_STATUS = '/convoai/v5/sip/status'
 export const REMOTE_CONVOAI_GET_CUSTOM_PRESET =

--- a/Web/Scenes/VoiceAgent/src/constants/api/schema/agent.test.ts
+++ b/Web/Scenes/VoiceAgent/src/constants/api/schema/agent.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'bun:test'
+import { startAgentRequestBodySchema } from '@/constants/api/schema/agent'
+
+describe('startAgentRequestBodySchema', () => {
+  test('keeps top-level app_feature when parsing latest start payload', () => {
+    const payload = startAgentRequestBodySchema.parse({
+      app_id: 'app-123',
+      preset_name: 'intelligent_assistant',
+      app_feature: {
+        enable_aivad: true,
+        pause_state_enabled: true,
+        enable_local_bvc: true
+      },
+      convoai_body: {
+        properties: {
+          channel: 'demo',
+          agent_rtc_uid: 'agent-uid',
+          remote_rtc_uids: ['user-uid'],
+          asr: {
+            language: 'zh-CN'
+          }
+        }
+      }
+    })
+
+    expect(payload.app_feature).toEqual({
+      enable_aivad: true,
+      pause_state_enabled: true,
+      enable_local_bvc: true
+    })
+  })
+})

--- a/Web/Scenes/VoiceAgent/src/constants/api/schema/agent.ts
+++ b/Web/Scenes/VoiceAgent/src/constants/api/schema/agent.ts
@@ -1,5 +1,11 @@
 import * as z from 'zod'
 
+const appFeatureSchema = z.object({
+  enable_aivad: z.boolean().optional(),
+  pause_state_enabled: z.boolean().optional(),
+  enable_local_bvc: z.boolean().optional()
+})
+
 const convoaiBodyPropertiesSchema = z.object({
   channel: z.string(),
   token: z.string().optional(),
@@ -122,6 +128,7 @@ export const startAgentRequestBodySchema = z.object({
   basic_auth_username: z.string().optional(),
   basic_auth_password: z.string().optional(),
   preset_name: z.string().optional(),
+  app_feature: appFeatureSchema.optional(),
   preset_type: z
     .enum(['standard', 'standard_avatar', 'independent', 'custom_private'])
     .optional(),

--- a/Web/Scenes/VoiceAgent/src/conversational-ai-api/README.md
+++ b/Web/Scenes/VoiceAgent/src/conversational-ai-api/README.md
@@ -1,6 +1,6 @@
 # ConversationalAI API (Web)
 
-> Version: 2.0.2
+> Version: 2.2.0
 
 ## Prerequisites
 

--- a/Web/Scenes/VoiceAgent/src/conversational-ai-api/index.ts
+++ b/Web/Scenes/VoiceAgent/src/conversational-ai-api/index.ts
@@ -1,9 +1,9 @@
 import { logger as agoraLogger } from '@agora-js/report'
 import type { IAgoraRTCClient } from 'agora-rtc-sdk-ng'
 import type { ChannelType, RTMClient, RTMEvents } from 'agora-rtm'
-import { ELoggerType, factoryFormatLog, logger, genTraceID } from './utils/logger'
+import { handlePresenceStates } from '@/conversational-ai-api/presence'
+import { parseTurnFinishedMessage } from '@/lib/latency-metrics'
 import {
-  type EAgentState,
   EChatMessagePriority,
   EChatMessageType,
   EConversationalAIAPIEvents,
@@ -17,19 +17,27 @@ import {
   type IConversationalAIAPIEventHandlers,
   type IMessageSalStatus,
   type ITranscriptHelperItem,
+  type ITurnFinishedMessage,
   type IUserTranscription,
   NotFoundError,
   type TAgentMetric,
+  type TAgentTurnFinished,
   type TMessageReceipt,
   type TModuleError,
   type TStateChangeEvent
 } from './type'
 import { EventHelper } from './utils/event'
+import {
+  ELoggerType,
+  factoryFormatLog,
+  genTraceID,
+  logger
+} from './utils/logger'
 import { CovSubRenderController } from './utils/sub-render'
 
 const TAG = 'ConversationalAIAPI'
 // const CONSOLE_LOG_PREFIX = `[${TAG}]`
-const VERSION = '2.0.2'
+const VERSION = '2.2.0'
 
 const formatLog = factoryFormatLog({ tag: TAG })
 
@@ -620,6 +628,45 @@ export class ConversationalAIAPI extends EventHelper<IConversationalAIAPIEventHa
       event
     )
   }
+  private onAgentListeningChanged(agentUserId: string, isListening: boolean) {
+    this.callMessagePrint(
+      ELoggerType.debug,
+      `>>> ${EConversationalAIAPIEvents.AGENT_LISTENING_CHANGED}`,
+      agentUserId,
+      isListening
+    )
+    this.emit(
+      EConversationalAIAPIEvents.AGENT_LISTENING_CHANGED,
+      agentUserId,
+      isListening
+    )
+  }
+  private onAgentThinkingChanged(agentUserId: string, isThinking: boolean) {
+    this.callMessagePrint(
+      ELoggerType.debug,
+      `>>> ${EConversationalAIAPIEvents.AGENT_THINKING_CHANGED}`,
+      agentUserId,
+      isThinking
+    )
+    this.emit(
+      EConversationalAIAPIEvents.AGENT_THINKING_CHANGED,
+      agentUserId,
+      isThinking
+    )
+  }
+  private onAgentSpeakingChanged(agentUserId: string, isSpeaking: boolean) {
+    this.callMessagePrint(
+      ELoggerType.debug,
+      `>>> ${EConversationalAIAPIEvents.AGENT_SPEAKING_CHANGED}`,
+      agentUserId,
+      isSpeaking
+    )
+    this.emit(
+      EConversationalAIAPIEvents.AGENT_SPEAKING_CHANGED,
+      agentUserId,
+      isSpeaking
+    )
+  }
   private onAgentInterrupted(
     agentUserId: string,
     event: { turnID: number; timestamp: number }
@@ -634,6 +681,15 @@ export class ConversationalAIAPI extends EventHelper<IConversationalAIAPIEventHa
   }
   private onDebugLog(message: string) {
     this.emit(EConversationalAIAPIEvents.DEBUG_LOG, message)
+  }
+  private onAgentTurnFinished(agentUserId: string, turn: TAgentTurnFinished) {
+    this.callMessagePrint(
+      ELoggerType.debug,
+      `>>> ${EConversationalAIAPIEvents.AGENT_TURN_FINISHED}`,
+      agentUserId,
+      turn
+    )
+    this.emit(EConversationalAIAPIEvents.AGENT_TURN_FINISHED, agentUserId, turn)
   }
   private onAgentMetrics(agentUserId: string, metrics: TAgentMetric) {
     this.callMessagePrint(
@@ -784,6 +840,13 @@ export class ConversationalAIAPI extends EventHelper<IConversationalAIAPIEventHa
           `>>> [traceID:${traceId}] ${ERTMEvents.MESSAGE}`,
           parsedMessage
         )
+        const turn = parseTurnFinishedMessage(
+          parsedMessage as ITurnFinishedMessage
+        )
+        if (turn) {
+          this.onAgentTurnFinished(message.publisher, turn)
+          return
+        }
         this.covSubRenderController.handleMessage(parsedMessage, {
           publisher: message.publisher
         })
@@ -799,6 +862,13 @@ export class ConversationalAIAPI extends EventHelper<IConversationalAIAPIEventHa
           `>>> [traceID:${traceId}] ${ERTMEvents.MESSAGE}`,
           parsedMessage
         )
+        const turn = parseTurnFinishedMessage(
+          parsedMessage as ITurnFinishedMessage
+        )
+        if (turn) {
+          this.onAgentTurnFinished(message.publisher, turn)
+          return
+        }
         this.covSubRenderController.handleMessage(parsedMessage, {
           publisher: message.publisher
         })
@@ -826,21 +896,46 @@ export class ConversationalAIAPI extends EventHelper<IConversationalAIAPIEventHa
       `Publisher: ${presence.publisher}`
     )
     // Handle the presence event
-    const stateChanged = presence.stateChanged
-    if (stateChanged?.state && stateChanged?.turn_id) {
+    const stateChanged = presence.stateChanged || {}
+    const mapped = handlePresenceStates(presence.publisher, {
+      timestamp: presence.timestamp,
+      states: stateChanged as Record<string, string>
+    })
+    if (mapped.agentStateChanged) {
       this.callMessagePrint(
         ELoggerType.debug,
         `>>> [traceID:${traceId}] ${ERTMEvents.PRESENCE}`,
-        `State changed: ${stateChanged.state}, Turn ID: ${stateChanged.turn_id}, timestamp: ${presence.timestamp}`
+        `State changed: ${mapped.agentStateChanged.event.state}, Turn ID: ${mapped.agentStateChanged.event.turnID}, timestamp: ${presence.timestamp}`
       )
-      this.covSubRenderController.handleAgentStatus(
-        presence as Omit<RTMEvents.PresenceEvent, 'stateChanged'> & {
-          stateChanged: {
-            state: EAgentState
-            turn_id: string
-          }
-        }
+      this.onAgentStateChanged(
+        mapped.agentStateChanged.agentUserId,
+        mapped.agentStateChanged.event
       )
+    }
+    if (mapped.agentListeningChanged) {
+      this.onAgentListeningChanged(
+        mapped.agentListeningChanged.agentUserId,
+        mapped.agentListeningChanged.isListening
+      )
+    }
+    if (mapped.agentThinkingChanged) {
+      this.onAgentThinkingChanged(
+        mapped.agentThinkingChanged.agentUserId,
+        mapped.agentThinkingChanged.isThinking
+      )
+    }
+    if (mapped.agentSpeakingChanged) {
+      this.onAgentSpeakingChanged(
+        mapped.agentSpeakingChanged.agentUserId,
+        mapped.agentSpeakingChanged.isSpeaking
+      )
+    }
+    if (
+      mapped.agentStateChanged ||
+      mapped.agentListeningChanged ||
+      mapped.agentThinkingChanged ||
+      mapped.agentSpeakingChanged
+    ) {
       return
     }
     this.callMessagePrint(

--- a/Web/Scenes/VoiceAgent/src/conversational-ai-api/presence.test.ts
+++ b/Web/Scenes/VoiceAgent/src/conversational-ai-api/presence.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from 'bun:test'
+import { handlePresenceStates } from '@/conversational-ai-api/presence'
+
+describe('handlePresenceStates', () => {
+  test('keeps HLD coarse state and fine-grained states in one pass', () => {
+    const result = handlePresenceStates('agent-user-1', {
+      timestamp: 1000,
+      states: {
+        state: 'listening',
+        turn_id: '3',
+        listening: 'true',
+        thinking: 'false',
+        speaking: 'false'
+      }
+    })
+
+    expect(result).toEqual({
+      agentStateChanged: {
+        agentUserId: 'agent-user-1',
+        event: {
+          reason: '',
+          state: 'listening',
+          timestamp: 1000,
+          turnID: 3
+        }
+      },
+      agentListeningChanged: {
+        agentUserId: 'agent-user-1',
+        isListening: true
+      },
+      agentThinkingChanged: {
+        agentUserId: 'agent-user-1',
+        isThinking: false
+      },
+      agentSpeakingChanged: {
+        agentUserId: 'agent-user-1',
+        isSpeaking: false
+      }
+    })
+  })
+
+  test('returns only fine-grained state changes when coarse state is absent', () => {
+    const result = handlePresenceStates('agent-user-2', {
+      timestamp: 2000,
+      states: {
+        listening: 'false',
+        speaking: 'true'
+      }
+    })
+
+    expect(result).toEqual({
+      agentStateChanged: null,
+      agentListeningChanged: {
+        agentUserId: 'agent-user-2',
+        isListening: false
+      },
+      agentThinkingChanged: null,
+      agentSpeakingChanged: {
+        agentUserId: 'agent-user-2',
+        isSpeaking: true
+      }
+    })
+  })
+})

--- a/Web/Scenes/VoiceAgent/src/conversational-ai-api/presence.ts
+++ b/Web/Scenes/VoiceAgent/src/conversational-ai-api/presence.ts
@@ -1,0 +1,86 @@
+import type {
+  EAgentState,
+  TStateChangeEvent
+} from '@/conversational-ai-api/type'
+
+type PresenceStates = Record<string, string>
+
+export type PresenceStateChanges = {
+  agentStateChanged: {
+    agentUserId: string
+    event: TStateChangeEvent
+  } | null
+  agentListeningChanged: {
+    agentUserId: string
+    isListening: boolean
+  } | null
+  agentThinkingChanged: {
+    agentUserId: string
+    isThinking: boolean
+  } | null
+  agentSpeakingChanged: {
+    agentUserId: string
+    isSpeaking: boolean
+  } | null
+}
+
+function parseBooleanState(value: string | undefined) {
+  if (value === 'true') {
+    return true
+  }
+  if (value === 'false') {
+    return false
+  }
+  return null
+}
+
+export function handlePresenceStates(
+  agentUserId: string,
+  input: {
+    timestamp: number
+    states: PresenceStates
+  }
+): PresenceStateChanges {
+  const { states, timestamp } = input
+  const state = states.state as EAgentState | undefined
+  const turnId = Number(states.turn_id)
+  const listening = parseBooleanState(states.listening)
+  const thinking = parseBooleanState(states.thinking)
+  const speaking = parseBooleanState(states.speaking)
+
+  return {
+    agentStateChanged:
+      state && Number.isFinite(turnId)
+        ? {
+            agentUserId,
+            event: {
+              state,
+              turnID: turnId,
+              timestamp,
+              reason: ''
+            }
+          }
+        : null,
+    agentListeningChanged:
+      listening === null
+        ? null
+        : {
+            agentUserId,
+            isListening: listening
+          },
+    agentThinkingChanged:
+      thinking === null
+        ? null
+        : {
+            agentUserId,
+            isThinking: thinking
+          },
+    agentSpeakingChanged:
+      speaking === null
+        ? null
+        : {
+            agentUserId,
+            isSpeaking: speaking
+          }
+  }
+}

--- a/Web/Scenes/VoiceAgent/src/conversational-ai-api/type.ts
+++ b/Web/Scenes/VoiceAgent/src/conversational-ai-api/type.ts
@@ -8,6 +8,7 @@ import type {
   UID
 } from 'agora-rtc-sdk-ng'
 import type { RTMEvents } from 'agora-rtm'
+import type { LatencyTurn } from '@/lib/latency-metrics'
 
 /**
  * Transcript modes for the Conversational AI API
@@ -41,6 +42,7 @@ export enum EMessageType {
   AGENT_TRANSCRIPTION = 'assistant.transcription',
   MSG_INTERRUPTED = 'message.interrupt',
   MSG_METRICS = 'message.metrics',
+  TURN_FINISHED = 'turn.finished',
   MSG_ERROR = 'message.error',
   /** @deprecated */
   MSG_STATE = 'message.state',
@@ -105,8 +107,12 @@ export enum ERTCCustomEvents {
  */
 export enum EConversationalAIAPIEvents {
   AGENT_STATE_CHANGED = 'agent-state-changed',
+  AGENT_LISTENING_CHANGED = 'agent-listening-changed',
+  AGENT_THINKING_CHANGED = 'agent-thinking-changed',
+  AGENT_SPEAKING_CHANGED = 'agent-speaking-changed',
   AGENT_INTERRUPTED = 'agent-interrupted',
   AGENT_METRICS = 'agent-metrics',
+  AGENT_TURN_FINISHED = 'agent-turn-finished',
   AGENT_ERROR = 'agent-error',
   TRANSCRIPT_UPDATED = 'transcript-updated',
   DEBUG_LOG = 'debug-log',
@@ -160,6 +166,8 @@ export type TAgentMetric = {
   value: number
   timestamp: number
 }
+
+export type TAgentTurnFinished = LatencyTurn
 
 /**
  * Message receipt type definition
@@ -277,12 +285,28 @@ export interface IConversationalAIAPIEventHandlers {
     agentUserId: string,
     event: TStateChangeEvent
   ) => void
+  [EConversationalAIAPIEvents.AGENT_LISTENING_CHANGED]: (
+    agentUserId: string,
+    isListening: boolean
+  ) => void
+  [EConversationalAIAPIEvents.AGENT_THINKING_CHANGED]: (
+    agentUserId: string,
+    isThinking: boolean
+  ) => void
+  [EConversationalAIAPIEvents.AGENT_SPEAKING_CHANGED]: (
+    agentUserId: string,
+    isSpeaking: boolean
+  ) => void
   [EConversationalAIAPIEvents.AGENT_INTERRUPTED]: (
     agentUserId: string,
     event: {
       turnID: number
       timestamp: number
     }
+  ) => void
+  [EConversationalAIAPIEvents.AGENT_TURN_FINISHED]: (
+    agentUserId: string,
+    turn: TAgentTurnFinished
   ) => void
   [EConversationalAIAPIEvents.AGENT_METRICS]: (
     agentUserId: string,
@@ -443,6 +467,25 @@ export interface IMessageMetrics {
   turn_id: number
   latency_ms: number
   send_ts: number
+}
+
+export interface ITurnFinishedMessage {
+  object?: EMessageType.TURN_FINISHED
+  event_type?: EMessageType.TURN_FINISHED
+  payload?: {
+    turn_id: number
+    agent_id: string
+    start?: {
+      start_at?: number
+    }
+    metrics?: {
+      e2e_latency_ms?: number
+      segmented_latency_ms?: Array<{
+        name?: string
+        latency?: number
+      }>
+    }
+  }
 }
 
 export interface IMessageError {

--- a/Web/Scenes/VoiceAgent/src/conversational-ai-api/utils/sub-render.ts
+++ b/Web/Scenes/VoiceAgent/src/conversational-ai-api/utils/sub-render.ts
@@ -1,6 +1,5 @@
 import { logger as agoraLogger } from '@agora-js/report'
 import type { RTMEvents } from 'agora-rtm'
-import { ELoggerType, factoryFormatLog, logger } from '../utils/logger'
 import {
   type EAgentState,
   EChatMessageType,
@@ -23,11 +22,12 @@ import {
   type TQueueItem,
   type TTranscriptHelperObjectWord
 } from '../type'
+import { ELoggerType, factoryFormatLog, logger } from '../utils/logger'
 
 const TAG = 'CovSubRenderController'
 const CONSOLE_LOG_PREFIX = `[${TAG}]`
 const SELF_USER_ID = 0
-const VERSION = '2.0.2'
+const VERSION = '2.2.0'
 
 const DEFAULT_INTERVAL = 200 // milliseconds
 const DEFAULT_CHUNK_INTERVAL = 100 // milliseconds, 10 char/s
@@ -1075,7 +1075,10 @@ export class CovSubRenderController {
     }
 
     if (isMessageSalStatus) {
-      this.handleMessageSalStatus(options.publisher, message as unknown as any)
+      this.handleMessageSalStatus(
+        options.publisher,
+        message as unknown as IMessageSalStatus
+      )
       return
     }
   }

--- a/Web/Scenes/VoiceAgent/src/lib/latency-metrics.test.ts
+++ b/Web/Scenes/VoiceAgent/src/lib/latency-metrics.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  buildLatencyReportPayload,
+  buildLatencySummary,
+  buildReportRows,
+  buildTranscriptByTurnId,
+  parseTurnFinishedMessage
+} from '@/lib/latency-metrics'
+
+describe('latency metrics helpers', () => {
+  test('parses turn.finished payload into normalized turn metrics', () => {
+    const turn = parseTurnFinishedMessage({
+      event_type: 'turn.finished',
+      payload: {
+        turn_id: 2,
+        agent_id: 'agent-123',
+        start: {
+          start_at: 1773901219000
+        },
+        metrics: {
+          e2e_latency_ms: 1294,
+          segmented_latency_ms: [
+            { name: 'algorithm_processing', latency: 120 },
+            { name: 'asr_ttlw', latency: 598 },
+            { name: 'llm_ttft', latency: 202 },
+            { name: 'tts_ttfb', latency: 178 },
+            { name: 'transport', latency: 196 }
+          ]
+        }
+      }
+    })
+
+    expect(turn).toEqual({
+      agentId: 'agent-123',
+      turnId: 2,
+      timestamp: 1773901219000,
+      e2eLatencyMs: 1294,
+      segmentedLatency: {
+        algorithmProcessingMs: 120,
+        asrTtlwMs: 598,
+        llmTtftMs: 202,
+        transportMs: 196,
+        ttsTtfbMs: 178
+      }
+    })
+  })
+
+  test('builds a UI summary from a normalized turn', () => {
+    const summary = buildLatencySummary({
+      agentId: 'agent-123',
+      turnId: 9,
+      timestamp: 1773901219000,
+      e2eLatencyMs: 1418,
+      segmentedLatency: {
+        algorithmProcessingMs: 279,
+        asrTtlwMs: 204,
+        llmTtftMs: 536,
+        transportMs: 314,
+        ttsTtfbMs: 174
+      }
+    })
+
+    expect(summary).toEqual({
+      turnId: 9,
+      e2eLatencyMs: 1418,
+      rtcTransportMs: 314,
+      algorithmProcessingMs: 279,
+      asrTtlwMs: 204,
+      llmTtftMs: 536,
+      ttsTtfbMs: 174
+    })
+  })
+
+  test('builds upload payload with sorted turn events', () => {
+    const payload = buildLatencyReportPayload({
+      agentId: 'agent-123',
+      channel: 'agent_debug_FD61811A',
+      presetName: 'intelligent_assistant',
+      presetDisplayName: '智能助手',
+      callStartAt: 1773901218000,
+      transcriptByTurnId: {
+        1: {
+          agentText: '你好，有什么可以帮您？',
+          userText: '你好，我想了解一下你们的产品'
+        },
+        3: {
+          agentText: '当然，我可以先介绍一下方案。',
+          userText: '你先介绍一下产品方案'
+        }
+      },
+      turns: [
+        {
+          agentId: 'agent-123',
+          turnId: 3,
+          timestamp: 1773901219100,
+          e2eLatencyMs: 1300,
+          segmentedLatency: {
+            algorithmProcessingMs: 130,
+            asrTtlwMs: 430,
+            llmTtftMs: 300,
+            transportMs: 200,
+            ttsTtfbMs: 240
+          }
+        },
+        {
+          agentId: 'agent-123',
+          turnId: 1,
+          timestamp: 1773901219000,
+          e2eLatencyMs: 1200,
+          segmentedLatency: {
+            algorithmProcessingMs: 100,
+            asrTtlwMs: 400,
+            llmTtftMs: 280,
+            transportMs: 180,
+            ttsTtfbMs: 240
+          }
+        }
+      ]
+    })
+
+    expect(payload).toEqual({
+      agent_id: 'agent-123',
+      channel: 'agent_debug_FD61811A',
+      preset_name: 'intelligent_assistant',
+      preset_display_name: '智能助手',
+      call_start_at: 1773901218000,
+      turn_event: [
+        {
+          turn_id: 1,
+          transcription: {
+            assistant: '你好，有什么可以帮您？',
+            user: '你好，我想了解一下你们的产品'
+          },
+          metrics: {
+            e2e_latency_ms: 1200,
+            segmented_latency_ms: [
+              { latency: 100, name: 'algorithm_processing' },
+              { latency: 400, name: 'asr_ttlw' },
+              { latency: 280, name: 'llm_ttft' },
+              { latency: 240, name: 'tts_ttfb' },
+              { latency: 180, name: 'transport' }
+            ]
+          }
+        },
+        {
+          turn_id: 3,
+          transcription: {
+            assistant: '当然，我可以先介绍一下方案。',
+            user: '你先介绍一下产品方案'
+          },
+          metrics: {
+            e2e_latency_ms: 1300,
+            segmented_latency_ms: [
+              { latency: 130, name: 'algorithm_processing' },
+              { latency: 430, name: 'asr_ttlw' },
+              { latency: 300, name: 'llm_ttft' },
+              { latency: 240, name: 'tts_ttfb' },
+              { latency: 200, name: 'transport' }
+            ]
+          }
+        }
+      ]
+    })
+  })
+
+  test('builds report rows from api metrics and local transcript cache', () => {
+    const rows = buildReportRows({
+      metrics: {
+        agent_id: 'agent-123',
+        call_start_at: 1773901218000,
+        channel: 'agent_debug_FD61811A',
+        preset_display_name: '智能助手',
+        preset_name: 'intelligent_assistant',
+        turn_event: [
+          {
+            turn_id: 1,
+            transcription: {
+              assistant: '接口返回的智能体字幕',
+              user: '接口返回的用户字幕'
+            },
+            metrics: {
+              e2e_latency_ms: 1200,
+              segmented_latency_ms: [
+                { latency: 100, name: 'algorithm_processing' },
+                { latency: 400, name: 'asr_ttlw' },
+                { latency: 280, name: 'llm_ttft' },
+                { latency: 240, name: 'tts_ttfb' },
+                { latency: 180, name: 'transport' }
+              ]
+            }
+          }
+        ]
+      },
+      transcriptByTurnId: {
+        1: {
+          agentText: '本地缓存的智能体字幕',
+          userText: '本地缓存的用户字幕'
+        }
+      }
+    })
+
+    expect(rows).toEqual({
+      averages: {
+        algorithmProcessingMs: 100,
+        asrTtlwMs: 400,
+        e2eLatencyMs: 1200,
+        llmTtftMs: 280,
+        rtcTransportMs: 180,
+        ttsTtfbMs: 240
+      },
+      rows: [
+        {
+          agentText: '接口返回的智能体字幕',
+          algorithmProcessingMs: 100,
+          asrTtlwMs: 400,
+          e2eLatencyMs: 1200,
+          llmTtftMs: 280,
+          rtcTransportMs: 180,
+          ttsTtfbMs: 240,
+          turnId: 1,
+          userText: '接口返回的用户字幕'
+        }
+      ]
+    })
+  })
+
+  test('groups transcript history into per-turn user and agent text', () => {
+    const transcript = buildTranscriptByTurnId([
+      {
+        turn_id: 1,
+        uid: '0',
+        text: '你好，我想了解一下你们的产品'
+      },
+      {
+        turn_id: 1,
+        uid: '1234',
+        text: '你好，有什么可以帮您？'
+      },
+      {
+        turn_id: 2,
+        uid: '0',
+        text: '延迟表现怎么样？'
+      }
+    ])
+
+    expect(transcript).toEqual({
+      1: {
+        agentText: '你好，有什么可以帮您？',
+        userText: '你好，我想了解一下你们的产品'
+      },
+      2: {
+        agentText: undefined,
+        userText: '延迟表现怎么样？'
+      }
+    })
+  })
+})

--- a/Web/Scenes/VoiceAgent/src/lib/latency-metrics.ts
+++ b/Web/Scenes/VoiceAgent/src/lib/latency-metrics.ts
@@ -1,0 +1,325 @@
+type RawSegmentedLatency = {
+  name?: string
+  latency?: number
+}
+
+type RawTurnFinishedPayload = {
+  turn_id?: number
+  agent_id?: string
+  start?: {
+    start_at?: number
+  }
+  metrics?: {
+    e2e_latency_ms?: number
+    segmented_latency_ms?: RawSegmentedLatency[]
+  }
+}
+
+export type LatencyTurn = {
+  agentId: string
+  turnId: number
+  timestamp: number
+  e2eLatencyMs: number
+  segmentedLatency: {
+    algorithmProcessingMs: number
+    asrTtlwMs: number
+    llmTtftMs: number
+    transportMs: number
+    ttsTtfbMs: number
+  }
+}
+
+export type MessageLatencyInfo = {
+  turnId: number
+  e2eLatencyMs: number
+  rtcTransportMs: number
+  algorithmProcessingMs: number
+  asrTtlwMs: number
+  llmTtftMs: number
+  ttsTtfbMs: number
+}
+
+export type LatencyReportPayload = {
+  agent_id: string
+  channel: string
+  preset_name: string
+  preset_display_name: string
+  call_start_at: number
+  turn_event: Array<{
+    turn_id: number
+    transcription?: {
+      assistant?: string
+      user?: string
+    }
+    metrics: {
+      e2e_latency_ms: number
+      segmented_latency_ms: Array<{
+        name: string
+        latency: number
+      }>
+    }
+  }>
+}
+
+export type AgentMetricsResponse = {
+  agent_id: string
+  channel: string
+  preset_name: string
+  preset_display_name: string
+  call_start_at: number
+  turn_event: Array<{
+    turn_id: number
+    transcription?: {
+      assistant?: string
+      user?: string
+    }
+    metrics: {
+      e2e_latency_ms: number
+      segmented_latency_ms: Array<{
+        name: string
+        latency: number
+      }>
+    }
+  }>
+}
+
+export type TranscriptByTurnId = Record<
+  number,
+  {
+    userText?: string
+    agentText?: string
+  }
+>
+
+export type TranscriptLikeItem = {
+  turn_id: number
+  uid: string
+  text: string
+}
+
+export type ReportRow = {
+  turnId: number
+  userText: string
+  agentText: string
+  e2eLatencyMs: number
+  rtcTransportMs: number
+  algorithmProcessingMs: number
+  asrTtlwMs: number
+  llmTtftMs: number
+  ttsTtfbMs: number
+}
+
+export type ReportRowSet = {
+  rows: ReportRow[]
+  averages: Omit<ReportRow, 'turnId' | 'userText' | 'agentText'>
+}
+
+const SEGMENT_ORDER = [
+  'algorithm_processing',
+  'asr_ttlw',
+  'llm_ttft',
+  'tts_ttfb',
+  'transport'
+] as const
+
+function numberOrZero(value: unknown) {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0
+}
+
+function mapSegments(segments: RawSegmentedLatency[] | undefined) {
+  const byName = new Map<string, number>()
+
+  for (const segment of segments || []) {
+    if (!segment?.name) {
+      continue
+    }
+    byName.set(segment.name, numberOrZero(segment.latency))
+  }
+
+  return {
+    algorithmProcessingMs: byName.get('algorithm_processing') ?? 0,
+    asrTtlwMs: byName.get('asr_ttlw') ?? 0,
+    llmTtftMs: byName.get('llm_ttft') ?? 0,
+    transportMs: byName.get('transport') ?? 0,
+    ttsTtfbMs: byName.get('tts_ttfb') ?? 0
+  }
+}
+
+function normalizePayload(message: unknown): RawTurnFinishedPayload | null {
+  if (!message || typeof message !== 'object') {
+    return null
+  }
+
+  const raw = message as {
+    event_type?: string
+    object?: string
+    payload?: RawTurnFinishedPayload
+  } & RawTurnFinishedPayload
+
+  const messageType = raw.event_type || raw.object
+  if (messageType !== 'turn.finished') {
+    return null
+  }
+
+  return raw.payload ?? raw
+}
+
+export function parseTurnFinishedMessage(message: unknown): LatencyTurn | null {
+  const payload = normalizePayload(message)
+  if (!payload?.agent_id || typeof payload.turn_id !== 'number') {
+    return null
+  }
+
+  return {
+    agentId: payload.agent_id,
+    turnId: payload.turn_id,
+    timestamp: numberOrZero(payload.start?.start_at),
+    e2eLatencyMs: numberOrZero(payload.metrics?.e2e_latency_ms),
+    segmentedLatency: mapSegments(payload.metrics?.segmented_latency_ms)
+  }
+}
+
+export function buildLatencySummary(turn: LatencyTurn): MessageLatencyInfo {
+  return {
+    turnId: turn.turnId,
+    e2eLatencyMs: turn.e2eLatencyMs,
+    rtcTransportMs: turn.segmentedLatency.transportMs,
+    algorithmProcessingMs: turn.segmentedLatency.algorithmProcessingMs,
+    asrTtlwMs: turn.segmentedLatency.asrTtlwMs,
+    llmTtftMs: turn.segmentedLatency.llmTtftMs,
+    ttsTtfbMs: turn.segmentedLatency.ttsTtfbMs
+  }
+}
+
+export function buildLatencyReportPayload(input: {
+  agentId: string
+  channel: string
+  presetName: string
+  presetDisplayName: string
+  callStartAt: number
+  turns: LatencyTurn[]
+  transcriptByTurnId?: TranscriptByTurnId
+}): LatencyReportPayload {
+  const turn_event = [...input.turns]
+    .sort((a, b) => a.turnId - b.turnId)
+    .map((turn) => ({
+      turn_id: turn.turnId,
+      transcription: input.transcriptByTurnId?.[turn.turnId]
+        ? {
+            assistant: input.transcriptByTurnId[turn.turnId]?.agentText,
+            user: input.transcriptByTurnId[turn.turnId]?.userText
+          }
+        : undefined,
+      metrics: {
+        e2e_latency_ms: turn.e2eLatencyMs,
+        segmented_latency_ms: SEGMENT_ORDER.map((name) => ({
+          name,
+          latency:
+            name === 'algorithm_processing'
+              ? turn.segmentedLatency.algorithmProcessingMs
+              : name === 'asr_ttlw'
+                ? turn.segmentedLatency.asrTtlwMs
+                : name === 'llm_ttft'
+                  ? turn.segmentedLatency.llmTtftMs
+                  : name === 'tts_ttfb'
+                    ? turn.segmentedLatency.ttsTtfbMs
+                    : turn.segmentedLatency.transportMs
+        }))
+      }
+    }))
+
+  return {
+    agent_id: input.agentId,
+    channel: input.channel,
+    preset_name: input.presetName,
+    preset_display_name: input.presetDisplayName,
+    call_start_at: input.callStartAt,
+    turn_event
+  }
+}
+
+function buildRow(
+  turnEvent: AgentMetricsResponse['turn_event'][number]
+): ReportRow {
+  const segments = mapSegments(turnEvent.metrics.segmented_latency_ms)
+
+  return {
+    turnId: turnEvent.turn_id,
+    userText: turnEvent.transcription?.user || '—',
+    agentText: turnEvent.transcription?.assistant || '—',
+    e2eLatencyMs: numberOrZero(turnEvent.metrics.e2e_latency_ms),
+    rtcTransportMs: segments.transportMs,
+    algorithmProcessingMs: segments.algorithmProcessingMs,
+    asrTtlwMs: segments.asrTtlwMs,
+    llmTtftMs: segments.llmTtftMs,
+    ttsTtfbMs: segments.ttsTtfbMs
+  }
+}
+
+export function buildReportRows(input: {
+  metrics: AgentMetricsResponse
+  transcriptByTurnId?: TranscriptByTurnId
+}): ReportRowSet {
+  const rows = [...(input.metrics.turn_event || [])]
+    .sort((a, b) => a.turn_id - b.turn_id)
+    .map((turnEvent) => buildRow(turnEvent))
+
+  const divisor = rows.length || 1
+  const averages = rows.reduce(
+    (acc, row) => ({
+      e2eLatencyMs: acc.e2eLatencyMs + row.e2eLatencyMs,
+      rtcTransportMs: acc.rtcTransportMs + row.rtcTransportMs,
+      algorithmProcessingMs:
+        acc.algorithmProcessingMs + row.algorithmProcessingMs,
+      asrTtlwMs: acc.asrTtlwMs + row.asrTtlwMs,
+      llmTtftMs: acc.llmTtftMs + row.llmTtftMs,
+      ttsTtfbMs: acc.ttsTtfbMs + row.ttsTtfbMs
+    }),
+    {
+      e2eLatencyMs: 0,
+      rtcTransportMs: 0,
+      algorithmProcessingMs: 0,
+      asrTtlwMs: 0,
+      llmTtftMs: 0,
+      ttsTtfbMs: 0
+    }
+  )
+
+  return {
+    rows,
+    averages: {
+      e2eLatencyMs: Math.round(averages.e2eLatencyMs / divisor),
+      rtcTransportMs: Math.round(averages.rtcTransportMs / divisor),
+      algorithmProcessingMs: Math.round(
+        averages.algorithmProcessingMs / divisor
+      ),
+      asrTtlwMs: Math.round(averages.asrTtlwMs / divisor),
+      llmTtftMs: Math.round(averages.llmTtftMs / divisor),
+      ttsTtfbMs: Math.round(averages.ttsTtfbMs / divisor)
+    }
+  }
+}
+
+export function buildTranscriptByTurnId(
+  history: TranscriptLikeItem[]
+): TranscriptByTurnId {
+  return history.reduce<TranscriptByTurnId>((acc, item) => {
+    const current = acc[item.turn_id] || {
+      userText: undefined,
+      agentText: undefined
+    }
+
+    acc[item.turn_id] =
+      Number(item.uid) === 0
+        ? {
+            ...current,
+            userText: item.text || current.userText
+          }
+        : {
+            ...current,
+            agentText: item.text || current.agentText
+          }
+
+    return acc
+  }, {})
+}

--- a/Web/Scenes/VoiceAgent/src/services/agent.ts
+++ b/Web/Scenes/VoiceAgent/src/services/agent.ts
@@ -6,6 +6,8 @@ import { localResSchema } from '@/app/api/token/utils'
 import {
   API_AGENT,
   API_AGENT_CUSTOM_PRESET,
+  API_AGENT_METRICS,
+  API_AGENT_METRICS_REPORT,
   API_AGENT_PING,
   API_AGENT_PRESETS,
   API_AGENT_STOP,
@@ -38,13 +40,14 @@ import type {
   IUserInfoInput
 } from '@/type/agent'
 import type { TDevModeQuery } from '@/type/dev'
+import type { IAgentMetrics, IAgentMetricsReportPayload } from '@/type/report'
 
 const DEFAULT_FETCH_TIMEOUT = 10000
 
 export class ResourceLimitError extends Error {
   public readonly code: ERROR_CODE | SIP_ERROR_CODE
 
-  constructor(code: ERROR_CODE, message?: string) {
+  constructor(code: ERROR_CODE | SIP_ERROR_CODE, message?: string) {
     super(message)
     this.name = 'ResourceLimitError'
     this.code = code
@@ -225,9 +228,20 @@ export const startAgent = async (
     ?.preset_name
     ? localStartAgentPropertiesSchema.parse(payload)
     : localOpensourceStartAgentPropertiesSchema.parse(payload)
+  const nextData = {
+    ...data,
+    app_feature: {
+      enable_aivad:
+        data.app_feature?.enable_aivad ??
+        data.advanced_features?.enable_aivad ??
+        false,
+      pause_state_enabled: data.app_feature?.pause_state_enabled ?? false,
+      enable_local_bvc: data.app_feature?.enable_local_bvc ?? true
+    }
+  }
 
   try {
-    const opensourceData = data as z.infer<
+    const opensourceData = nextData as z.infer<
       typeof localOpensourceStartAgentPropertiesSchema
     >
     const llm_system_messages = opensourceData.llm?.system_messages?.trim()
@@ -261,7 +275,7 @@ export const startAgent = async (
         'Content-Type': 'application/json',
         Authorization: `Bearer ${Cookies.get('token')}`
       },
-      body: JSON.stringify(data)
+      body: JSON.stringify(nextData)
     },
     {
       abortController
@@ -269,6 +283,13 @@ export const startAgent = async (
   )
 
   const respData = await resp?.json()
+  if (!respData?.data) {
+    throw new Error(
+      respData?.msg ||
+        respData?.message ||
+        `Agent start failed${respData?.code ? ` (${respData.code})` : ''}`
+    )
+  }
   const remoteRespSchema = basicRemoteResSchema.extend({
     data: remoteAgentStartRespDataSchema
   })
@@ -298,6 +319,17 @@ export const startAgentDev = async (
   const query = generateDevModeQuery({ devMode })
   const url = `${API_AGENT}${query}`
   const data = localStartAgentPropertiesSchema.parse(payload)
+  const nextData = {
+    ...data,
+    app_feature: {
+      enable_aivad:
+        data.app_feature?.enable_aivad ??
+        data.advanced_features?.enable_aivad ??
+        false,
+      pause_state_enabled: data.app_feature?.pause_state_enabled ?? false,
+      enable_local_bvc: data.app_feature?.enable_local_bvc ?? true
+    }
+  }
   const resp = await fetchWithTimeout(
     url,
     {
@@ -306,7 +338,7 @@ export const startAgentDev = async (
         'Content-Type': 'application/json',
         Authorization: `Bearer ${Cookies.get('token')}`
       },
-      body: JSON.stringify(data)
+      body: JSON.stringify(nextData)
     },
     {
       abortController
@@ -445,6 +477,73 @@ export const retrievePresetById = async (id: string) => {
   }
   const remoteRespSchema = basicRemoteResSchema.extend({
     data: z.array(remoteAgentCustomPresetItem)
+  })
+  const remoteResp = remoteRespSchema.parse(respData)
+  return remoteResp.data
+}
+
+export const reportAgentMetrics = async (
+  payload: IAgentMetricsReportPayload,
+  options?: TDevModeQuery
+) => {
+  const query = generateDevModeQuery(options ?? {})
+  const url = `${API_AGENT_METRICS_REPORT}${query}`
+  const resp = await fetchWithTimeout(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${Cookies.get('token')}`
+    },
+    body: JSON.stringify(payload)
+  })
+  const respData = await resp?.json()
+  const remoteRespSchema = basicRemoteResSchema.extend({
+    data: z
+      .object({
+        uploaded_at: z.number().optional()
+      })
+      .optional()
+  })
+  return remoteRespSchema.parse(respData)
+}
+
+export const getAgentMetrics = async (
+  agentId: string
+): Promise<IAgentMetrics> => {
+  const resp = await fetchWithTimeout(API_AGENT_METRICS(agentId), {
+    method: 'GET'
+  })
+  const respData = await resp?.json()
+  const remoteRespSchema = z.object({
+    code: z.number().optional(),
+    msg: z.string().optional(),
+    data: z.object({
+      agent_id: z.string(),
+      channel: z.string(),
+      preset_name: z.string(),
+      preset_display_name: z.string(),
+      call_start_at: z.number(),
+      turn_event: z.array(
+        z.object({
+          turn_id: z.number(),
+          transcription: z
+            .object({
+              assistant: z.string().optional(),
+              user: z.string().optional()
+            })
+            .optional(),
+          metrics: z.object({
+            e2e_latency_ms: z.number(),
+            segmented_latency_ms: z.array(
+              z.object({
+                name: z.string(),
+                latency: z.number()
+              })
+            )
+          })
+        })
+      )
+    })
   })
   const remoteResp = remoteRespSchema.parse(respData)
   return remoteResp.data

--- a/Web/Scenes/VoiceAgent/src/store/agent.ts
+++ b/Web/Scenes/VoiceAgent/src/store/agent.ts
@@ -39,13 +39,13 @@ export interface IAgentSettings {
   conversationTimerEndTimestamp: number | null
   settings: TAgentSettings
   transcriptionRenderMode: ETranscriptHelperMode
-  enableRenderModeFallback: boolean
   onFormSetValue?: UseFormSetValue<z.infer<typeof publicAgentSettingSchema>>
   updateFormSetValue: (
     cb: UseFormSetValue<z.infer<typeof publicAgentSettingSchema>>
   ) => void
-  updateTranscriptionRenderMode: (mode: ETranscriptHelperMode) => void
+  enableRenderModeFallback: boolean
   updateEnableRenderModeFallback: (enabled: boolean) => void
+  updateTranscriptionRenderMode: (mode: ETranscriptHelperMode) => void
   updateSettings: (settings: TAgentSettings) => void
   updatePresets: (
     newPresets: z.infer<typeof agentPresetSchema>[],
@@ -107,6 +107,11 @@ const DEFAULT_SETTINGS = {
     enable_aivad: false,
     enable_rtm: true,
     enable_sal: false
+  },
+  app_feature: {
+    enable_aivad: false,
+    pause_state_enabled: false,
+    enable_local_bvc: true
   },
   // !SPECIAL CASE[audio_scenario]
   parameters: {

--- a/Web/Scenes/VoiceAgent/src/store/global.ts
+++ b/Web/Scenes/VoiceAgent/src/store/global.ts
@@ -9,8 +9,15 @@ export interface IGlobalStore {
   showSubtitle: boolean
   setShowSubtitle: (showSubtitle: boolean) => void
   onClickSubtitle: () => void
+  showLiveMetrics: boolean
+  setShowLiveMetrics: (showLiveMetrics: boolean) => void
   isDevMode: boolean
   setIsDevMode: (isDevMode: boolean) => void
+  customAppId: string
+  setCustomAppId: (customAppId: string) => void
+  isCustomAppIdOverrideEnabled: boolean
+  setCustomAppIdOverrideEnabled: (isCustomAppIdOverrideEnabled: boolean) => void
+  resetDevModeOverrides: () => void
   isRTCCompatible: boolean
   showCompatibilityDialog: boolean
   setShowCompatibilityDialog: (showCompatibilityDialog: boolean) => void
@@ -64,8 +71,17 @@ export const useGlobalStore = create<IGlobalStore>()(
       setShowSubtitle: (showSubtitle: boolean) => set({ showSubtitle }),
       onClickSubtitle: () =>
         set((state) => ({ showSubtitle: !state.showSubtitle })),
+      showLiveMetrics: true,
+      setShowLiveMetrics: (showLiveMetrics: boolean) =>
+        set({ showLiveMetrics }),
       isDevMode: false,
       setIsDevMode: (isDevMode: boolean) => set({ isDevMode }),
+      customAppId: '',
+      setCustomAppId: (customAppId: string) => set({ customAppId }),
+      isCustomAppIdOverrideEnabled: false,
+      setCustomAppIdOverrideEnabled: (isCustomAppIdOverrideEnabled: boolean) =>
+        set({ isCustomAppIdOverrideEnabled }),
+      resetDevModeOverrides: () => set({ isCustomAppIdOverrideEnabled: false }),
       isRTCCompatible: true,
       setIsRTCCompatible: (isRTCCompatible: boolean) =>
         set({ isRTCCompatible }),
@@ -107,7 +123,9 @@ export const useGlobalStore = create<IGlobalStore>()(
     {
       name: 'global-store',
       partialize: (state) => ({
-        isPresetDigitalReminderIgnored: state.isPresetDigitalReminderIgnored
+        isPresetDigitalReminderIgnored: state.isPresetDigitalReminderIgnored,
+        customAppId: state.customAppId,
+        isCustomAppIdOverrideEnabled: state.isCustomAppIdOverrideEnabled
       })
     }
   )

--- a/Web/Scenes/VoiceAgent/src/store/index.ts
+++ b/Web/Scenes/VoiceAgent/src/store/index.ts
@@ -1,5 +1,6 @@
 export { useAgentSalAudioStore, useAgentSettingsStore } from '@/store/agent'
 export { useChatStore } from '@/store/chat'
 export { useGlobalStore } from '@/store/global'
+export { useReportStore } from '@/store/report'
 export { useRTCStore } from '@/store/rtc'
 export { useUserInfoStore } from '@/store/userInfo'

--- a/Web/Scenes/VoiceAgent/src/store/report.ts
+++ b/Web/Scenes/VoiceAgent/src/store/report.ts
@@ -1,0 +1,146 @@
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+import type {
+  LatencyTurn,
+  TranscriptByTurnId,
+  TranscriptLikeItem
+} from '@/lib/latency-metrics'
+import { buildTranscriptByTurnId } from '@/lib/latency-metrics'
+
+export type ReportSession = {
+  agentId?: string
+  channel: string
+  presetName: string
+  presetDisplayName: string
+  callStartAt: number
+  turns: LatencyTurn[]
+  transcriptByTurnId: TranscriptByTurnId
+  uploadedAt?: number
+}
+
+type StartReportSessionInput = Omit<
+  ReportSession,
+  'turns' | 'transcriptByTurnId' | 'uploadedAt'
+>
+
+export interface IReportStore {
+  activeSession: ReportSession | null
+  sessionsByAgentId: Record<string, ReportSession>
+  startSession: (input: StartReportSessionInput) => void
+  attachAgentId: (agentId: string) => void
+  upsertTurn: (turn: LatencyTurn) => void
+  syncTranscript: (history: TranscriptLikeItem[]) => void
+  finalizeActiveSession: () => ReportSession | null
+  markUploaded: (agentId: string, uploadedAt?: number) => void
+  clearActiveSession: () => void
+}
+
+export const useReportStore = create<IReportStore>()(
+  persist(
+    (set, get) => ({
+      activeSession: null,
+      sessionsByAgentId: {},
+      startSession: (input) =>
+        set(() => ({
+          activeSession: {
+            ...input,
+            turns: [],
+            transcriptByTurnId: {}
+          }
+        })),
+      attachAgentId: (agentId) =>
+        set((state) => ({
+          activeSession: state.activeSession
+            ? {
+                ...state.activeSession,
+                agentId
+              }
+            : state.activeSession
+        })),
+      upsertTurn: (turn) =>
+        set((state) => {
+          if (!state.activeSession) {
+            return state
+          }
+
+          const turns = [...state.activeSession.turns]
+          const existingIndex = turns.findIndex(
+            (item) => item.turnId === turn.turnId
+          )
+
+          if (existingIndex >= 0) {
+            turns[existingIndex] = turn
+          } else {
+            turns.push(turn)
+          }
+
+          return {
+            activeSession: {
+              ...state.activeSession,
+              turns: turns.sort((a, b) => a.turnId - b.turnId)
+            }
+          }
+        }),
+      syncTranscript: (history) =>
+        set((state) => {
+          if (!state.activeSession) {
+            return state
+          }
+
+          return {
+            activeSession: {
+              ...state.activeSession,
+              transcriptByTurnId: buildTranscriptByTurnId(history)
+            }
+          }
+        }),
+      finalizeActiveSession: () => {
+        const { activeSession } = get()
+        if (!activeSession?.agentId) {
+          return null
+        }
+
+        set((state) => ({
+          sessionsByAgentId: {
+            ...state.sessionsByAgentId,
+            [activeSession.agentId as string]: activeSession
+          }
+        }))
+
+        return activeSession
+      },
+      markUploaded: (agentId, uploadedAt = Date.now()) =>
+        set((state) => {
+          const targetSession =
+            (state.activeSession?.agentId === agentId
+              ? state.activeSession
+              : state.sessionsByAgentId[agentId]) || null
+
+          if (!targetSession) {
+            return state
+          }
+
+          const nextSession = {
+            ...targetSession,
+            agentId,
+            uploadedAt
+          }
+
+          return {
+            activeSession:
+              state.activeSession?.agentId === agentId
+                ? nextSession
+                : state.activeSession,
+            sessionsByAgentId: {
+              ...state.sessionsByAgentId,
+              [agentId]: nextSession
+            }
+          }
+        }),
+      clearActiveSession: () => set(() => ({ activeSession: null }))
+    }),
+    {
+      name: 'report-store'
+    }
+  )
+)

--- a/Web/Scenes/VoiceAgent/src/type/report.ts
+++ b/Web/Scenes/VoiceAgent/src/type/report.ts
@@ -1,0 +1,14 @@
+import type {
+  AgentMetricsResponse,
+  LatencyReportPayload,
+  ReportRowSet,
+  TranscriptByTurnId
+} from '@/lib/latency-metrics'
+
+export type IAgentMetricsReportPayload = LatencyReportPayload
+
+export type IAgentMetrics = AgentMetricsResponse
+
+export type ITranscriptCache = TranscriptByTurnId
+
+export type IReportRowSet = ReportRowSet


### PR DESCRIPTION
 ## Summary
  - sync the Shengwang `VoiceAgent` scene with the latest AgoraIO `VoiceAgent` metrics/report flow
  - add in-app metrics report upload/query APIs and `/reports/[agentId]` report page
  - update ConvoAI event handling for `turn.finished`, presence state parsing, and latest `app_feature` start payload compatibility

  ## Changes
  - add latency metrics parsing, report payload builders, report store, and report-related types
  - add `/api/agent/metrics/report` and `/api/agent/metrics/[agentId]` proxy routes
  - add report page UI and report entry points in preset forms
  - add live metrics toggle and subtitle latency display
  - sync start-agent request schema/service logic with top-level `app_feature`
  - bump `conversational-ai-api` web integration behavior to match `2.2.0`
  - add regression tests for route payload compatibility, schema sync, presence parsing, and latency metrics helpers

  ## Test Plan
  - [x] `bun test src/app/api/agent/route.test.ts src/constants/api/schema/agent.test.ts src/constants/agent/schema.test.ts src/conversational-ai-api/presence.test.ts src/
  lib/latency-metrics.test.ts`
  - [x] `./node_modules/.bin/biome check messages/en-US.json messages/zh-CN.json src/app/api/agent/route.ts src/app/api/agent/route.test.ts 'src/app/api/agent/metrics/
  [agentId]/route.ts' src/app/api/agent/metrics/report/route.ts 'src/app/reports/[agentId]/page.tsx' 'src/app/reports/[agentId]/report-page.tsx' src/components/home/agent-
  card.tsx src/components/home/agent-control.tsx src/components/home/agent-setting/form-custom-private.tsx src/components/home/agent-setting/form-demo.tsx src/components/
  home/live-metrics-toggle.tsx src/components/home/subtitle.tsx src/constants/agent/schema.ts src/constants/agent/schema.test.ts src/constants/api/index.ts src/constants/
  api/schema/agent.ts src/constants/api/schema/agent.test.ts src/conversational-ai-api/README.md src/conversational-ai-api/index.ts src/conversational-ai-api/presence.ts
  src/conversational-ai-api/presence.test.ts src/conversational-ai-api/type.ts src/conversational-ai-api/utils/sub-render.ts src/lib/latency-metrics.ts src/lib/latency-
  metrics.test.ts src/services/agent.ts src/store/agent.ts src/store/global.ts src/store/index.ts src/store/report.ts src/type/report.ts`
  - [x] `bun run build`

  ## Notes
  - build still prints the existing Next.js workspace-root warning caused by multiple lockfiles, but build completes successfully